### PR TITLE
prop type hierarchy, phase 2

### DIFF
--- a/cpp/src/deck.gl/core/lib/layer.cpp
+++ b/cpp/src/deck.gl/core/lib/layer.cpp
@@ -7,7 +7,7 @@ using namespace deckgl;
 
 // TODO - auto generate from language-independent prop definition schema
 
-const std::map<const std::string, const Prop*> LayerProps::propTypes = {
+static const std::map<const std::string, const Prop*> propTypes = {
     {"visible",
      new PropType<Layer, bool>{[](const Layer::Props* props) { return props->visible; },
                                [](Layer::Props* props, bool value) { return props->visible = value; }, true}},
@@ -33,6 +33,8 @@ const std::map<const std::string, const Prop*> LayerProps::propTypes = {
     {"wrapLongitude",
      new PropType<Layer, bool>{[](const Layer::Props* props) { return props->wrapLongitude; },
                                [](Layer::Props* props, bool value) { return props->wrapLongitude = value; }, false}}};
+
+auto LayerProps::getOwnPropTypes() const -> const std::map<const std::string, const Prop*>* { return &propTypes; }
 
 /*
 class LayerPropTypes {

--- a/cpp/src/deck.gl/core/lib/layer.h
+++ b/cpp/src/deck.gl/core/lib/layer.h
@@ -129,10 +129,6 @@ class LayerState {
 
 class LayerProps : public Props {
  public:
-  static const std::map<const std::string, const Prop*> propTypes;
-
-  virtual auto getPropTypes() -> const std::map<const std::string, const Prop*> { return LayerProps::propTypes; }
-
   LayerProps()
       // TODO - how to deal with data ?
 
@@ -201,6 +197,10 @@ class LayerProps : public Props {
   std::function<void()> onDragStart;
   std::function<void()> onDrag;
   std::function<void()> onDragEnd;
+
+ protected:
+  auto getParentProps() const -> std::shared_ptr<Props> { return nullptr; }
+  auto getOwnPropTypes() const -> const std::map<const std::string, const Prop*>*;
 };
 
 class Layer : public Component {  // : public Component

--- a/cpp/src/deck.gl/core/lifecycle/prop-types.cpp
+++ b/cpp/src/deck.gl/core/lifecycle/prop-types.cpp
@@ -2,10 +2,24 @@
 
 using namespace deckgl;
 
+//
+// TODO clang does not appear to have C++17 map.merge(), using map.insert()
+auto Props::getPropTypes() -> const std::map<const std::string, const Prop*>* {
+  if (this->_mergedPropTypes.empty()) {
+    const auto* ownPropTypes = this->getOwnPropTypes();
+    this->_mergedPropTypes.insert(ownPropTypes->begin(), ownPropTypes->end());
+    if (auto parentProps = this->getParentProps()) {
+      const auto* parentPropTypes = parentProps->getOwnPropTypes();
+      this->_mergedPropTypes.insert(parentPropTypes->begin(), parentPropTypes->end());
+    }
+  }
+  return &(this->_mergedPropTypes);
+}
+
 auto Props::compare(const Props* oldProps) -> bool {
   auto propTypes = this->getPropTypes();
 
-  for (auto element : propTypes) {
+  for (auto element : *propTypes) {
     // Accessing KEY from element
     std::string name = element.first;
     // Accessing VALUE from element.

--- a/cpp/src/deck.gl/core/lifecycle/prop-types.h
+++ b/cpp/src/deck.gl/core/lifecycle/prop-types.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <string>
 
 namespace deckgl {
@@ -36,10 +37,18 @@ struct PropType : public Prop {
 
 class Props {
  public:
+  Props() {}
   virtual ~Props() {}
-  virtual auto getPropTypes() -> const std::map<const std::string, const Prop*> = 0;
 
+  auto getPropTypes() -> const std::map<const std::string, const Prop*>*;
   auto compare(const Props* oldProps) -> bool;
+
+ protected:
+  virtual auto getParentProps() const -> std::shared_ptr<Props> { return nullptr; }
+  virtual auto getOwnPropTypes() const -> const std::map<const std::string, const Prop*>* = 0;
+
+ private:
+  std::map<const std::string, const Prop*> _mergedPropTypes;
 };
 
 }  // namespace deckgl

--- a/cpp/src/deck.gl/layers/line-layer/line-layer-fragment.glsl.h
+++ b/cpp/src/deck.gl/layers/line-layer/line-layer-fragment.glsl.h
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const char* fs = R"shader(
+static const char* fs = R"GLSL(
 #define SHADER_NAME line-layer-fragment-shader
 
 precision highp float;
@@ -33,4 +33,4 @@ void main(void) {
 
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }
-)shader";
+)GLSL";

--- a/cpp/src/deck.gl/layers/line-layer/line-layer-vertex.glsl.h
+++ b/cpp/src/deck.gl/layers/line-layer/line-layer-vertex.glsl.h
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const char* vs = R"shader(
+static const char* vs = R"GLSL(
 #define SHADER_NAME line-layer-vertex-shader
 
 attribute vec3 positions;
@@ -85,4 +85,4 @@ void main(void) {
   vColor = vec4(instanceColors.rgb, instanceColors.a * opacity);
   DECKGL_FILTER_COLOR(vColor, geometry);
 }
-)shader";
+)GLSL";

--- a/cpp/src/deck.gl/layers/line-layer/line-layer.cpp
+++ b/cpp/src/deck.gl/layers/line-layer/line-layer.cpp
@@ -4,7 +4,7 @@
 
 using namespace deckgl;
 
-const std::map<const std::string, const Prop*> LineLayer::Props::propTypes = {
+const std::map<const std::string, const Prop*> propTypes = {
     // {"widthUnits", new PropType<LineLayer, std::string>{
     //                    [](const LineLayer::Props* props) { return props->widthUnits; },
     //                    [](LineLayer::Props* props, bool value) { return props->widthUnits = value; }, true}},
@@ -18,6 +18,8 @@ const std::map<const std::string, const Prop*> LineLayer::Props::propTypes = {
      new PropType<LineLayer, float>{[](const LineLayer::Props* props) { return props->widthMaxPixels; },
                                     [](LineLayer::Props* props, float value) { return props->widthMaxPixels = value; },
                                     std::numeric_limits<float>::max()}}};
+
+auto LineLayer::Props::getOwnPropTypes() const -> const std::map<const std::string, const Prop*>* { return &propTypes; }
 
 /*
 const defaultProps = {

--- a/cpp/src/deck.gl/layers/line-layer/line-layer.h
+++ b/cpp/src/deck.gl/layers/line-layer/line-layer.h
@@ -38,28 +38,27 @@ const DEFAULT_COLOR = [0, 0, 0, 255];
 
 class LineLayerProps : public LayerProps {
  public:
-  using super = LayerProps;
-
-  static const std::map<const std::string, const Prop*> propTypes;
-
-  LineLayerProps()
-      : widthUnits{"pixels"}, widthScale{1}, widthMinPixels{0}, widthMaxPixels{std::numeric_limits<float>::max()} {}
-
   std::string widthUnits;  // : 'pixels',
   float widthScale;        //  {type: 'number', value: 1, min: 0},
   float widthMinPixels;    //  {type: 'number', value: 0, min: 0},
   float widthMaxPixels;    //  {type: 'number', value: Number.MAX_SAFE_INTEGER, min: 0}
 
   /*
-      // std::function<(auto row) -> Vector3<double>> getSourcePosition; //
+    // std::function<(auto row) -> Vector3<double>> getSourcePosition; //
     {type: 'accessor', value: x => x.sourcePosition},
-      // std::function<(auto row) -> Vector3<double>> getTargetPosition; //
+    // std::function<(auto row) -> Vector3<double>> getTargetPosition; //
     {type: 'accessor', value: x => x.targetPosition},
-      // std::function<(auto row) -> ColorRGBA> getColor; //  {type: 'accessor',
+    // std::function<(auto row) -> ColorRGBA> getColor; //  {type: 'accessor',
     value: DEFAULT_COLOR},
-      // std::function<(auto row) -> float> getWidth; //  {type: 'accessor',
+    // std::function<(auto row) -> float> getWidth; //  {type: 'accessor',
     value: 1},
-    */
+   */
+  LineLayerProps()
+      : widthUnits{"pixels"}, widthScale{1}, widthMinPixels{0}, widthMaxPixels{std::numeric_limits<float>::max()} {}
+
+ protected:
+  auto getParentProps() const -> std::shared_ptr<Props> { return std::shared_ptr<Props>(new Layer::Props()); }
+  auto getOwnPropTypes() const -> const std::map<const std::string, const Prop *> *;
 };
 
 class LineLayerState : public LayerState {

--- a/cpp/src/deck.gl/layers/scatterplot-layer/scatterplot-layer-fragment.glsl.h
+++ b/cpp/src/deck.gl/layers/scatterplot-layer/scatterplot-layer-fragment.glsl.h
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const char* fs = R"shader(
+static const char* fs = R"GLSL(
 #define SHADER_NAME scatterplot-layer-fragment-shader
 
 precision highp float;
@@ -61,4 +61,4 @@ void main(void) {
   gl_FragColor.a *= inCircle;
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }
-)shader";
+)GLSL";

--- a/cpp/src/deck.gl/layers/scatterplot-layer/scatterplot-layer-vertex.glsl.h
+++ b/cpp/src/deck.gl/layers/scatterplot-layer/scatterplot-layer-vertex.glsl.h
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const char *vs = R"shader(
+static const char *vs = R"GLSL(
 #define SHADER_NAME scatterplot-layer-vertex-shader
 
 attribute vec3 positions;
@@ -83,4 +83,4 @@ void main(void) {
   vLineColor = vec4(instanceLineColors.rgb, instanceLineColors.a * opacity);
   DECKGL_FILTER_COLOR(vLineColor, geometry);
 }
-)shader";
+)GLSL";

--- a/cpp/src/deck.gl/layers/scatterplot-layer/scatterplot-layer.cpp
+++ b/cpp/src/deck.gl/layers/scatterplot-layer/scatterplot-layer.cpp
@@ -4,7 +4,7 @@
 
 using namespace deckgl;
 
-const std::map<const std::string, const Prop*> ScatterplotLayer::Props::propTypes = {
+const std::map<const std::string, const Prop*> propTypes = {
     {"filled", new PropType<ScatterplotLayer, bool>{
                    [](const ScatterplotLayer::Props* props) { return props->filled; },
                    [](ScatterplotLayer::Props* props, bool value) { return props->filled = value; }, true}},
@@ -41,6 +41,10 @@ const std::map<const std::string, const Prop*> ScatterplotLayer::Props::propType
                             [](const ScatterplotLayer::Props* props) { return props->radiusMaxPixels; },
                             [](ScatterplotLayer::Props* props, float value) { return props->radiusMaxPixels = value; },
                             std::numeric_limits<float>::max()}}};
+
+auto ScatterplotLayer::Props::getOwnPropTypes() const -> const std::map<const std::string, const Prop*>* {
+  return &propTypes;
+}
 
 /*
 const DEFAULT_COLOR = [0, 0, 0, 255];

--- a/cpp/src/deck.gl/layers/scatterplot-layer/scatterplot-layer.h
+++ b/cpp/src/deck.gl/layers/scatterplot-layer/scatterplot-layer.h
@@ -35,23 +35,6 @@ namespace deckgl {
 
 class ScatterplotLayerProps : public LayerProps {
  public:
-  using super = LayerProps;
-
-  static const std::map<const std::string, const Prop*> propTypes;
-
-  ScatterplotLayerProps()
-      : filled{true},
-        stroked{false},
-
-        lineWidthUnits{"meters"},
-        lineWidthScale{1},
-        lineWidthMinPixels{1},
-        lineWidthMaxPixels{0},
-
-        radiusScale{1},
-        radiusMinPixels{1},
-        radiusMaxPixels{0} {}
-
   bool filled;
   bool stroked;
 
@@ -71,6 +54,23 @@ class ScatterplotLayerProps : public LayerProps {
   // std::function<(auto row) -> ColorRGBA> getLineColor, // {type: 'accessor',
   // value: DEFAULT_COLOR}, std::function<(auto row) -> float> getLineWidth, //
   // {type: 'accessor', value: 1},
+
+  ScatterplotLayerProps()
+      : filled{true},
+        stroked{false},
+
+        lineWidthUnits{"meters"},
+        lineWidthScale{1},
+        lineWidthMinPixels{1},
+        lineWidthMaxPixels{0},
+
+        radiusScale{1},
+        radiusMinPixels{1},
+        radiusMaxPixels{0} {}
+
+ protected:
+  auto getParentProps() const -> std::shared_ptr<Props> { return std::shared_ptr<Props>(new Layer::Props()); }
+  auto getOwnPropTypes() const -> const std::map<const std::string, const Prop *> *;
 };
 
 class ScatterplotLayerState : public LayerState {};

--- a/cpp/tests/deck.gl/core/lib/layer-test.cpp
+++ b/cpp/tests/deck.gl/core/lib/layer-test.cpp
@@ -33,6 +33,11 @@ TEST(Layer, Props) {
   EXPECT_TRUE(layerProps1->compare(layerProps2.get()));
   layerProps2->opacity = 0.5;
   EXPECT_FALSE(layerProps1->compare(layerProps2.get()));
+
+  auto propTypes = layerProps1->getPropTypes();
+
+  EXPECT_TRUE(propTypes->count("opacity"));
+  EXPECT_FALSE(propTypes->count("radiusScale"));
 }
 
 int main(int argc, char **argv) {

--- a/cpp/tests/layers/line-layer/line-layer-test.cpp
+++ b/cpp/tests/layers/line-layer/line-layer-test.cpp
@@ -20,7 +20,7 @@
 
 #include <gtest/gtest.h>
 
-#include "layers/layers.h"
+#include "deck.gl/layers.h"
 #include <memory>
 
 using namespace deckgl;
@@ -31,5 +31,16 @@ TEST(LineLayer, Props) {
 
   EXPECT_TRUE(layerProps1->compare(layerProps2.get()));
   layerProps2->opacity = 0.5;
+  layerProps2->widthScale = 0.5;
   EXPECT_FALSE(layerProps1->compare(layerProps2.get()));
+
+  auto propTypes = layerProps1->getPropTypes();
+  EXPECT_TRUE(propTypes->count("opacity") == 1);
+  EXPECT_TRUE(propTypes->count("radiusScale") == 0);
+  EXPECT_TRUE(propTypes->count("radiusScale") == 1);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/cpp/tests/layers/scatterplot-layer/scatterplot-layer-test.cpp
+++ b/cpp/tests/layers/scatterplot-layer/scatterplot-layer-test.cpp
@@ -21,7 +21,7 @@
 
 #include <gtest/gtest.h>
 
-#include "layers/layers.h"
+#include "deck.gl/layers.h"
 #include <memory>
 
 using namespace deckgl;
@@ -32,5 +32,23 @@ TEST(ScatterplotLayer, Props) {
 
   EXPECT_TRUE(layerProps1->compare(layerProps2.get()));
   layerProps2->opacity = 0.5;
+  layerProps2->radiusScale = 0.5;
   EXPECT_FALSE(layerProps1->compare(layerProps2.get()));
+
+  auto propTypes = layerProps1->getPropTypes();
+  EXPECT_TRUE(propTypes->count("opacity") == 1);
+  EXPECT_TRUE(propTypes->count("radiusScale") == 1);
+
+  for (auto element : propTypes) {
+    // Accessing KEY from element
+    std::string name = element.first;
+    // Accessing VALUE from element.
+    const Prop* propType = element.second;
+    // std::cout<<word<<" :: "<<count<<std::endl;
+  }
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
- Merge prop type maps along the layer inheritance hierarchy. 
- `<Layer>::Props::getPropTypes()` now returns the merged map.

Notes for another PR:
- The test setup for the sublayers seem flaky / non-functional, i.e. are giving false positives.