### PR TITLE
Added coding style markdown

### DIFF
--- a/docs/dev/coding-style.md
+++ b/docs/dev/coding-style.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-**deck.gl-native** follows [Google C++ Style Guide]([https://google.github.io/styleguide/cppguide.html](https://google.github.io/styleguide/cppguide.html)) with a few notable updates:
+### **deck.gl-native** follows [Google C++ Style Guide]([https://google.github.io/styleguide/cppguide.html](https://google.github.io/styleguide/cppguide.html)) with a few notable updates:
 
 - [Trailing Return Syntax](https://google.github.io/styleguide/cppguide.html#trailing_return) - we make use of trailing return syntax across the board
 - [Exceptions](https://google.github.io/styleguide/cppguide.html#Exceptions) - our code is exception-tolerant, so it is encouraged to use exceptions wherever it is appropriate
@@ -11,3 +11,9 @@
 - [Enumerator_Names](https://google.github.io/styleguide/cppguide.html#Enumerator_Names) - enumerator values are to use the same format as constant names
 - [Line Length](https://google.github.io/styleguide/cppguide.html#Line_Length) - allowed line length is 120 characters, up from 80
 - [Pointer_and_Reference_Expressions](https://google.github.io/styleguide/cppguide.html#Pointer_and_Reference_Expressions) - TBD
+
+
+### Assertions and Exceptions
+
+- `throw std::logic_error(string)` should be used for when a coding error is detected
+- `throw std::runtime_error(string)` should be used for when there is a validation error


### PR DESCRIPTION
`Pointer_and_Reference_Expressions` (`void*` vs `void *`) and `Constant_Names` (`k*` vs `CONSTANT`) are yet to be determined, ideally we finalize those before merging