### PR TITLE
Added cpplint config

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 Unfolded, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# Coding style and rule exceptions are documented at
+# https://github.com/UnfoldedInc/deck.gl-native/tree/master/docs/dev/coding-style.md
+
+# Stop searching for additional config files.
+set noparent
+
+linelength=120
+
+# To disable a rule:
+#filter=-[RULE]
+
+# To enable a rule:
+#filter=+[RULE]
+
+# For a list of rules run cpplint --filter=


### PR DESCRIPTION
We should use [cpplint](https://github.com/cpplint/cpplint) which is a fork of [Google Styleguide](https://github.com/google/styleguide) and is being updated more regularly.

Visual Studio plugin available at https://marketplace.visualstudio.com/items?itemName=mine.cpplint

There are currently a bunch of warnings, we should figure out which ones we might want to disable and add them to the config file (guide on how to do so is in the config file):
```
# To disable a rule:
#filter=-[RULE]

# To enable a rule:
#filter=+[RULE]

# For a list of rules run cpplint --filter=
```

With this in place, and assuming we follow the rules, does `clang-format` become redundant?