### PR TITLE
Add WebMercatorViewportOptions

### DIFF
--- a/cpp/modules/deck.gl/core/src/viewports/web-mercator-viewport.cpp
+++ b/cpp/modules/deck.gl/core/src/viewports/web-mercator-viewport.cpp
@@ -28,7 +28,7 @@ using namespace std;
 using namespace mathgl;
 using namespace deckgl;
 
-ViewMatrixOptions calculateViewMatrixOptions(const WebMercatorViewport::WebMercatorViewportOptions& opts) {
+ViewMatrixOptions calculateViewMatrixOptions(const WebMercatorViewport::Options& opts) {
   auto scale = pow(2, opts.zoom);
   double adjustedHeight = opts.height == 0 ? 1 : opts.height;
 
@@ -50,7 +50,7 @@ ViewMatrixOptions calculateViewMatrixOptions(const WebMercatorViewport::WebMerca
   return viewOpts;
 }
 
-ProjectionMatrixOptions calculateProjectionMatrixOptions(const WebMercatorViewport::WebMercatorViewportOptions& opts) {
+ProjectionMatrixOptions calculateProjectionMatrixOptions(const WebMercatorViewport::Options& opts) {
   double adjustedWidth = opts.width == 0 ? 1 : opts.width;
   double adjustedHeight = opts.height == 0 ? 1 : opts.height;
 
@@ -62,7 +62,7 @@ ProjectionMatrixOptions calculateProjectionMatrixOptions(const WebMercatorViewpo
                                  opts.farZMultiplier);
 }
 
-WebMercatorViewport::WebMercatorViewport(const WebMercatorViewport::WebMercatorViewportOptions& opts)
+WebMercatorViewport::WebMercatorViewport(const WebMercatorViewport::Options& opts)
     : Viewport("web-mercator-viewport", calculateViewMatrixOptions(opts), calculateProjectionMatrixOptions(opts), 0, 0,
                opts.width == 0 ? 1 : opts.width, opts.height == 0 ? 1 : opts.height) {
   // TODO(isaac): Need to cleanup the call to the superclass ctor. In JS this is done partway through this ctor,

--- a/cpp/modules/deck.gl/core/src/viewports/web-mercator-viewport.h
+++ b/cpp/modules/deck.gl/core/src/viewports/web-mercator-viewport.h
@@ -35,23 +35,37 @@ namespace deckgl {
 //
 class WebMercatorViewport : public Viewport {
  public:
-  struct WebMercatorViewportOptions {
-    int width = 1;
-    int height = 1;
-    double latitude = 0;
-    double longitude = 0;
-    double zoom = 11;
-    double pitch = 0;
-    double bearing = 0;
-    double altitude = 1.5;
-    double nearZMultiplier = 0.1;
-    double farZMultiplier = 1.01;
-    bool orthographic = false;
-    bool repeat = false;
-    double worldOffset = 0;
+  struct Options {
+    const int DEFAULT_WIDTH = 1;
+    const int DEFAULT_HEIGHT = 1;
+    const double DEFAULT_LONGITUDE = 0.0;
+    const double DEFAULT_LATITUDE = 0.0;
+    const double DEFAULT_ZOOM = 11.0;
+    const double DEFAULT_PITCH = 0.0;
+    const double DEFAULT_BEARING = 0.0;
+    const double DEFAULT_ALTITUDE = 1.5;
+    const double DEFAULT_NEAR_Z_MULTIPLIER = 0.1;
+    const double DEFAULT_FAR_Z_MULTIPLIER = 1.01;
+    const bool DEFAULT_ORTHOGRAPHIC = false;
+    const bool DEFAULT_REPEAT = false;
+    const double DEFAULT_WORLD_OFFSET = 0.0;
+
+    int width = DEFAULT_WIDTH;
+    int height = DEFAULT_HEIGHT;
+    double latitude = DEFAULT_LATITUDE;
+    double longitude = DEFAULT_LONGITUDE;
+    double zoom = DEFAULT_ZOOM;
+    double pitch = DEFAULT_PITCH;
+    double bearing = DEFAULT_BEARING;
+    double altitude = DEFAULT_ALTITUDE;
+    double nearZMultiplier = DEFAULT_NEAR_Z_MULTIPLIER;
+    double farZMultiplier = DEFAULT_FAR_Z_MULTIPLIER;
+    bool orthographic = DEFAULT_ORTHOGRAPHIC;
+    bool repeat = DEFAULT_REPEAT;
+    double worldOffset = DEFAULT_WORLD_OFFSET;
   };
 
-  WebMercatorViewport(const WebMercatorViewportOptions& options);
+  WebMercatorViewport(const Options& options);
 
   // elided subViewports feature
   // get subViewports()

--- a/cpp/modules/deck.gl/core/src/views/map-view.cpp
+++ b/cpp/modules/deck.gl/core/src/views/map-view.cpp
@@ -29,14 +29,24 @@ using namespace deckgl;
 using namespace mathgl;
 
 auto MapView::_getViewport(const Rectangle<int>& rect, shared_ptr<ViewState> viewState) const -> shared_ptr<Viewport> {
-  WebMercatorViewport::WebMercatorViewportOptions opts;
+  WebMercatorViewport::Options opts;
   opts.width = rect.w;
   opts.height = rect.h;
-  opts.longitude = viewState->longitude.value_or(0);
-  opts.latitude = viewState->latitude.value_or(0);
-  opts.zoom = viewState->zoom.value_or(11);
-  opts.pitch = viewState->pitch.value_or(0);
-  opts.bearing = viewState->bearing.value_or(0);
+  if (viewState->longitude) {
+    opts.longitude = viewState->longitude.value();
+  }
+  if (viewState->latitude) {
+    opts.latitude = viewState->latitude.value();
+  }
+  if (viewState->zoom) {
+    opts.zoom = viewState->zoom.value();
+  }
+  if (viewState->pitch) {
+    opts.pitch = viewState->pitch.value();
+  }
+  if (viewState->bearing) {
+    opts.bearing = viewState->bearing.value();
+  }
 
   return make_shared<WebMercatorViewport>(opts);
 }

--- a/cpp/modules/deck.gl/core/test/shaderlib/project/viewport-uniforms-test.cpp
+++ b/cpp/modules/deck.gl/core/test/shaderlib/project/viewport-uniforms-test.cpp
@@ -29,4 +29,7 @@ using namespace deckgl;
 
 TEST(ViewportUniforms, Simple) {
   // TODO(isaac): Add tests
+
+  // TODO: Check for non-finite outputs
+  // TODO: Check for coordinate origin (copy from JS)
 }

--- a/cpp/modules/deck.gl/core/test/viewports/web-mercator-viewport-test.cpp
+++ b/cpp/modules/deck.gl/core/test/viewports/web-mercator-viewport-test.cpp
@@ -33,7 +33,7 @@ auto const OFFSET_TOLERANCE = 1e-5;
 
 WebMercatorViewport makeTestViewport(int width, int height, double longitude, double latitude, double zoom,
                                      double pitch, double bearing) {
-  WebMercatorViewport::WebMercatorViewportOptions opts;
+  WebMercatorViewport::Options opts;
   opts.width = width;
   opts.height = height;
   opts.longitude = longitude;

--- a/cpp/modules/math.gl/web-mercator/src/web-mercator-utils.h
+++ b/cpp/modules/math.gl/web-mercator/src/web-mercator-utils.h
@@ -26,18 +26,20 @@
 
 #include "math.gl/core.h"
 
-#define PI M_PI
-#define PI_4 (M_PI / 4.0)
-#define DEGREES_TO_RADIANS (PI / 180.0)
-#define RADIANS_TO_DEGREES (180.0 / PI)
-#define TILE_SIZE 512
+namespace mathgl {
+
+const auto PI = M_PI;
+const auto PI_4 = PI / 4.0;
+const auto DEGREES_TO_RADIANS = PI / 180.0;
+const auto RADIANS_TO_DEGREES = 180.0 / PI;
+
+const auto TILE_SIZE = 512;
+
 // Average circumference (40075 km equatorial, 40007 km meridional)
-#define EARTH_CIRCUMFERENCE 40.03e6
+const auto EARTH_CIRCUMFERENCE = 40.03e6;
 
 // Mapbox default altitude
-#define DEFAULT_ALTITUDE 1.5
-
-namespace mathgl {
+const auto DEFAULT_ALTITUDE = 1.5;
 
 struct DistanceScales {
   Vector3<double> metersPerUnit;


### PR DESCRIPTION
Can't use named aggregate initializers (C++20 feature) so using separate statements instead. Follow up to #51.