### PR TITLE
probe.gl: Add compiler.h, assert.h, log.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ include(CTest)
 # Define source file lists per library
 
 ## probe.gl
-set(PROBEGL_HEADER_FILES
+set(PROBEGL_CORE_HEADER_FILES
     cpp/modules/probe.gl/core.h
     cpp/modules/probe.gl/core/src/platform.h
     cpp/modules/probe.gl/core/src/compiler.h
@@ -46,12 +46,12 @@ set(PROBEGL_HEADER_FILES
     cpp/modules/probe.gl/core/src/log.h
     cpp/modules/probe.gl/core/src/system-utils.h
 )
-set(PROBEGL_SOURCE_FILES
+set(PROBEGL_CORE_SOURCE_FILES
     cpp/modules/probe.gl/core/src/assert.cpp
     cpp/modules/probe.gl/core/src/log.cpp
     cpp/modules/probe.gl/core/src/system-utils.cpp
 )
-set(PROBEGL_TEST_FILES
+set(PROBEGL_CORE_TEST_FILES
 )
 
 ## math.gl

--- a/cpp/modules/probe.gl/core.h
+++ b/cpp/modules/probe.gl/core.h
@@ -18,9 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "./core/src/compiler.h"
-#include "./core/src/platform.h"
+#ifndef PROBEGL_CORE
+#define PROBEGL_CORE
 
 #include "./core/src/assert.h"
+#include "./core/src/compiler.h"
 #include "./core/src/log.h"
+#include "./core/src/platform.h"
 #include "./core/src/system-utils.h"
+
+#endif  // PROBEGL_CORE

--- a/cpp/modules/probe.gl/core/src/assert.cpp
+++ b/cpp/modules/probe.gl/core/src/assert.cpp
@@ -22,19 +22,17 @@
 // Copyright 2017 The Dawn Authors http://www.apache.org/licenses/LICENSE-2.0
 
 #include "./assert.h"  // NOLINT(build/include)
-#include "./log.h"
 
 #include <cstdlib>
 
-void HandleAssertionFailure(const char* file,
-                            const char* function,
-                            int line,
-                            const char* condition) {
-    dawn::ErrorLog() << "Assertion failure at " << file << ":" << line << " (" << function
-                     << "): " << condition;
-#if defined(DAWN_ABORT_ON_ASSERT)
-    abort();
+#include "./compiler.h"
+#include "./log.h"
+
+void HandleAssertionFailure(const char* file, const char* function, int line, const char* condition) {
+  probegl::ErrorLog() << "Assertion failure at " << file << ":" << line << " (" << function << "): " << condition;
+#if defined(PROBEGL_ABORT_ON_ASSERT)
+  abort();
 #else
-    DAWN_BREAKPOINT();
+  PROBEGL_BREAKPOINT();
 #endif
 }

--- a/cpp/modules/probe.gl/core/src/assert.h
+++ b/cpp/modules/probe.gl/core/src/assert.h
@@ -41,49 +41,46 @@
 // MSVC triggers a warning in /W4 for do {} while(0). SDL worked around this by using (0,0) and
 // points out that it looks like an owl face.
 #if defined(PROBEGL_COMPILER_MSVC)
-#    define PROBEGL_ASSERT_LOOP_CONDITION (0, 0)
+#define PROBEGL_ASSERT_LOOP_CONDITION (0, 0)
 #else
-#    define PROBEGL_ASSERT_LOOP_CONDITION (0)
+#define PROBEGL_ASSERT_LOOP_CONDITION (0)
 #endif
 
 // PROBEGL_ASSERT_CALLSITE_HELPER generates the actual assert code. In Debug it does what you would
 // expect of an assert and in release it tries to give hints to make the compiler generate better
 // code.
 #if defined(PROBEGL_ENABLE_ASSERTS)
-#    define PROBEGL_ASSERT_CALLSITE_HELPER(file, func, line, condition)  \
-        do {                                                          \
-            if (!(condition)) {                                       \
-                HandleAssertionFailure(file, func, line, #condition); \
-            }                                                         \
-        } while (PROBEGL_ASSERT_LOOP_CONDITION)
+#define PROBEGL_ASSERT_CALLSITE_HELPER(file, func, line, condition) \
+  do {                                                              \
+    if (!(condition)) {                                             \
+      HandleAssertionFailure(file, func, line, #condition);         \
+    }                                                               \
+  } while (PROBEGL_ASSERT_LOOP_CONDITION)
 #else
-#    if defined(PROBEGL_COMPILER_MSVC)
-#        define PROBEGL_ASSERT_CALLSITE_HELPER(file, func, line, condition) __assume(condition)
-#    elif defined(PROBEGL_COMPILER_CLANG) && defined(__builtin_assume)
-#        define PROBEGL_ASSERT_CALLSITE_HELPER(file, func, line, condition) __builtin_assume(condition)
-#    else
-#        define PROBEGL_ASSERT_CALLSITE_HELPER(file, func, line, condition) \
-            do {                                                         \
-                PROBEGL_UNUSED(sizeof(condition));                          \
-            } while (PROBEGL_ASSERT_LOOP_CONDITION)
-#    endif
+#if defined(PROBEGL_COMPILER_MSVC)
+#define PROBEGL_ASSERT_CALLSITE_HELPER(file, func, line, condition) __assume(condition)
+#elif defined(PROBEGL_COMPILER_CLANG) && defined(__builtin_assume)
+#define PROBEGL_ASSERT_CALLSITE_HELPER(file, func, line, condition) __builtin_assume(condition)
+#else
+#define PROBEGL_ASSERT_CALLSITE_HELPER(file, func, line, condition) \
+  do {                                                              \
+    PROBEGL_UNUSED(sizeof(condition));                              \
+  } while (PROBEGL_ASSERT_LOOP_CONDITION)
+#endif
 #endif
 
 #define PROBEGL_ASSERT(condition) PROBEGL_ASSERT_CALLSITE_HELPER(__FILE__, __func__, __LINE__, condition)
-#define PROBEGL_UNREACHABLE()                                                 \
-    do {                                                                   \
-        PROBEGL_ASSERT(PROBEGL_ASSERT_LOOP_CONDITION && "Unreachable code hit"); \
-        PROBEGL_BUILTIN_UNREACHABLE();                                        \
-    } while (PROBEGL_ASSERT_LOOP_CONDITION)
+#define PROBEGL_UNREACHABLE()                                                \
+  do {                                                                       \
+    PROBEGL_ASSERT(PROBEGL_ASSERT_LOOP_CONDITION && "Unreachable code hit"); \
+    PROBEGL_BUILTIN_UNREACHABLE();                                           \
+  } while (PROBEGL_ASSERT_LOOP_CONDITION)
 
 #if !defined(PROBEGL_SKIP_ASSERT_SHORTHANDS)
-#    define ASSERT PROBEGL_ASSERT
-#    define UNREACHABLE PROBEGL_UNREACHABLE
+#define ASSERT PROBEGL_ASSERT
+#define UNREACHABLE PROBEGL_UNREACHABLE
 #endif
 
-void HandleAssertionFailure(const char* file,
-                            const char* function,
-                            int line,
-                            const char* condition);
+void HandleAssertionFailure(const char* file, const char* function, int line, const char* condition);
 
 #endif  // COMMON_ASSERT_H_

--- a/cpp/modules/probe.gl/core/src/compiler.h
+++ b/cpp/modules/probe.gl/core/src/compiler.h
@@ -24,6 +24,9 @@
 #ifndef PROBEGL_COMPILER_H_
 #define PROBEGL_COMPILER_H_
 
+// Input Macros
+//  - PROBEGL_CPP_VERSION
+
 // Defines macros for compiler-specific functionality
 //  - PROBEGL_COMPILER_[CLANG|GCC|MSVC]: Compiler detection
 //  - PROBEGL_BREAKPOINT(): Raises an exception and breaks in the debugger
@@ -39,62 +42,61 @@
 
 // Clang and GCC, check for __clang__ too to catch clang-cl masquarading as MSVC
 #if defined(__GNUC__) || defined(__clang__)
-#    if defined(__clang__)
-#        define PROBEGL_COMPILER_CLANG
-#    else
-#        define PROBEGL_COMPILER_GCC
-#    endif
+#if defined(__clang__)
+#define PROBEGL_COMPILER_CLANG
+#else
+#define PROBEGL_COMPILER_GCC
+#endif
 
-#    if defined(__i386__) || defined(__x86_64__)
-#        define PROBEGL_BREAKPOINT() __asm__ __volatile__("int $3\n\t")
-#    else
-// TODO(cwallez@chromium.org): Implement breakpoint on all supported architectures
-#        define PROBEGL_BREAKPOINT()
-#    endif
+#if defined(__i386__) || defined(__x86_64__)
+#define PROBEGL_BREAKPOINT() __asm__ __volatile__("int $3\n\t")
+#else
+#define PROBEGL_BREAKPOINT()
+#endif
 
-#    define PROBEGL_BUILTIN_UNREACHABLE() __builtin_unreachable()
-#    define PROBEGL_LIKELY(x) __builtin_expect(!!(x), 1)
-#    define PROBEGL_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#define PROBEGL_BUILTIN_UNREACHABLE() __builtin_unreachable()
+#define PROBEGL_LIKELY(x) __builtin_expect(!!(x), 1)
+#define PROBEGL_UNLIKELY(x) __builtin_expect(!!(x), 0)
 
-#    if !defined(__has_cpp_attribute)
-#        define __has_cpp_attribute(name) 0
-#    endif
+#if !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(name) 0
+#endif
 
 // Use warn_unused_result on clang otherwise we can a c++1z extension warning in C++14 mode
 // Also avoid warn_unused_result with GCC because it is only a function attribute and not a type
 // attribute.
-#    if __has_cpp_attribute(warn_unused_result) && defined(__clang__)
-#        define PROBEGL_NO_DISCARD __attribute__((warn_unused_result))
-#    elif PROBEGL_CPP_VERSION >= 17 && __has_cpp_attribute(nodiscard)
-#        define PROBEGL_NO_DISCARD [[nodiscard]]
-#    endif
+#if __has_cpp_attribute(warn_unused_result) && defined(__clang__)
+#define PROBEGL_NO_DISCARD __attribute__((warn_unused_result))
+#elif PROBEGL_CPP_VERSION >= 17 && __has_cpp_attribute(nodiscard)
+#define PROBEGL_NO_DISCARD [[nodiscard]]  // NOLINT
+#endif
 
-#    define PROBEGL_DECLARE_UNUSED __attribute__((unused))
-#    if defined(NDEBUG)
-#        define PROBEGL_FORCE_INLINE inline __attribute__((always_inline))
-#    endif
+#define PROBEGL_DECLARE_UNUSED __attribute__((unused))
+#if defined(NDEBUG)
+#define PROBEGL_FORCE_INLINE inline __attribute__((always_inline))
+#endif
 
 // MSVC
 #elif defined(_MSC_VER)
-#    define PROBEGL_COMPILER_MSVC
+#define PROBEGL_COMPILER_MSVC
 
 extern void __cdecl __debugbreak(void);
-#    define PROBEGL_BREAKPOINT() __debugbreak()
+#define PROBEGL_BREAKPOINT() __debugbreak()
 
-#    define PROBEGL_BUILTIN_UNREACHABLE() __assume(false)
+#define PROBEGL_BUILTIN_UNREACHABLE() __assume(false)
 
 // Visual Studio 2017 15.3 adds support for [[nodiscard]]
-#    if _MSC_VER >= 1911 && PROBEGL_CPP_VERSION >= 17
-#        define PROBEGL_NO_DISCARD [[nodiscard]]
-#    endif
+#if _MSC_VER >= 1911 && PROBEGL_CPP_VERSION >= 17
+#define PROBEGL_NO_DISCARD [[nodiscard]]  // NOLINT
+#endif
 
-#    define PROBEGL_DECLARE_UNUSED
-#    if defined(NDEBUG)
-#        define PROBEGL_FORCE_INLINE __forceinline
-#    endif
+#define PROBEGL_DECLARE_UNUSED
+#if defined(NDEBUG)
+#define PROBEGL_FORCE_INLINE __forceinline
+#endif
 
 #else
-#    error "Unsupported compiler"
+#error "Unsupported compiler"
 #endif
 
 // It seems that (void) EXPR works on all compilers to silence the unused variable warning.
@@ -104,16 +106,16 @@ extern void __cdecl __debugbreak(void);
 
 // Add noop replacements for macros for features that aren't supported by the compiler.
 #if !defined(PROBEGL_LIKELY)
-#    define PROBEGL_LIKELY(X) X
+#define PROBEGL_LIKELY(X) X
 #endif
 #if !defined(PROBEGL_UNLIKELY)
-#    define PROBEGL_UNLIKELY(X) X
+#define PROBEGL_UNLIKELY(X) X
 #endif
 #if !defined(PROBEGL_NO_DISCARD)
-#    define PROBEGL_NO_DISCARD
+#define PROBEGL_NO_DISCARD
 #endif
 #if !defined(PROBEGL_FORCE_INLINE)
-#    define PROBEGL_FORCE_INLINE inline
+#define PROBEGL_FORCE_INLINE inline
 #endif
 
 #endif  // PROBEGL_COMPILER_H_

--- a/cpp/modules/probe.gl/core/src/log.cpp
+++ b/cpp/modules/probe.gl/core/src/log.cpp
@@ -21,105 +21,96 @@
 // Note: This file was inspired by the Dawn codebase at https://dawn.googlesource.com/dawn/
 // Copyright 2017 The Dawn Authors http://www.apache.org/licenses/LICENSE-2.0
 
-#include "./log.h"
+#include "./log.h"  // NOLINT(build/include)
+
+#include <cstdio>
 
 #include "./assert.h"
 #include "./platform.h"
 
-#include <cstdio>
-
-#if defined(DAWN_PLATFORM_ANDROID)
-# include <android/log.h>
+#if defined(PROBEGL_PLATFORM_ANDROID)
+#include <android/log.h>
 #endif
 
-namespace dawn {
+namespace probegl {
 
-    namespace {
+namespace {
 
-        const char* SeverityName(LogSeverity severity) {
-            switch (severity) {
-                case LogSeverity::Debug:
-                    return "Debug";
-                case LogSeverity::Info:
-                    return "Info";
-                case LogSeverity::Warning:
-                    return "Warning";
-                case LogSeverity::Error:
-                    return "Error";
-                default:
-                    UNREACHABLE();
-                    return "";
-            }
-        }
+const char* SeverityName(LogSeverity severity) {
+  switch (severity) {
+    case LogSeverity::Debug:
+      return "Debug";
+    case LogSeverity::Info:
+      return "Info";
+    case LogSeverity::Warning:
+      return "Warning";
+    case LogSeverity::Error:
+      return "Error";
+    default:
+      UNREACHABLE();
+      return "";
+  }
+}
 
-#if defined(DAWN_PLATFORM_ANDROID)
-        android_LogPriority AndroidLogPriority(LogSeverity severity) {
-            switch (severity) {
-                case LogSeverity::Debug:
-                    return ANDROID_LOG_INFO;
-                case LogSeverity::Info:
-                    return ANDROID_LOG_INFO;
-                case LogSeverity::Warning:
-                    return ANDROID_LOG_WARN;
-                case LogSeverity::Error:
-                    return ANDROID_LOG_ERROR;
-                default:
-                    UNREACHABLE();
-                    return ANDROID_LOG_ERROR;
-            }
-        }
-#endif  // defined(DAWN_PLATFORM_ANDROID)
+#if defined(PROBEGL_PLATFORM_ANDROID)
+android_LogPriority AndroidLogPriority(LogSeverity severity) {
+  switch (severity) {
+    case LogSeverity::Debug:
+      return ANDROID_LOG_INFO;
+    case LogSeverity::Info:
+      return ANDROID_LOG_INFO;
+    case LogSeverity::Warning:
+      return ANDROID_LOG_WARN;
+    case LogSeverity::Error:
+      return ANDROID_LOG_ERROR;
+    default:
+      UNREACHABLE();
+      return ANDROID_LOG_ERROR;
+  }
+}
+#endif  // defined(PROBEGL_PLATFORM_ANDROID)
 
-    }  // anonymous namespace
+}  // anonymous namespace
 
-    LogMessage::LogMessage(LogSeverity severity) : mSeverity(severity) {
-    }
+LogMessage::LogMessage(LogSeverity severity) : mSeverity(severity) {}
 
-    LogMessage::~LogMessage() {
-        std::string fullMessage = mStream.str();
+LogMessage::~LogMessage() {
+  std::string fullMessage = mStream.str();
 
-        // If this message has been moved, its stream is empty.
-        if (fullMessage.empty()) {
-            return;
-        }
+  // If this message has been moved, its stream is empty.
+  if (fullMessage.empty()) {
+    return;
+  }
 
-        const char* severityName = SeverityName(mSeverity);
+  const char* severityName = SeverityName(mSeverity);
 
-        FILE* outputStream = stdout;
-        if (mSeverity == LogSeverity::Warning || mSeverity == LogSeverity::Error) {
-            outputStream = stderr;
-        }
+  FILE* outputStream = stdout;
+  if (mSeverity == LogSeverity::Warning || mSeverity == LogSeverity::Error) {
+    outputStream = stderr;
+  }
 
-#if defined(DAWN_PLATFORM_ANDROID)
-        android_LogPriority androidPriority = AndroidLogPriority(mSeverity);
-        __android_log_print(androidPriority, "Dawn", "%s: %s\n", severityName, fullMessage.c_str());
-#else   // defined(DAWN_PLATFORM_ANDROID)
+#if defined(PROBEGL_PLATFORM_ANDROID)
+  android_LogPriority androidPriority = AndroidLogPriority(mSeverity);
+  __android_log_print(androidPriority, "probe.gl", "%s: %s\n", severityName, fullMessage.c_str());
+#else   // defined(PROBEGL_PLATFORM_ANDROID)
         // Note: we use fprintf because <iostream> includes static initializers.
-        fprintf(outputStream, "%s: %s\n", severityName, fullMessage.c_str());
-        fflush(outputStream);
-#endif  // defined(DAWN_PLATFORM_ANDROID)
-    }
+  fprintf(outputStream, "%s: %s\n", severityName, fullMessage.c_str());
+  fflush(outputStream);
+#endif  // defined(PROBEGL_PLATFORM_ANDROID)
+}
 
-    LogMessage DebugLog() {
-        return {LogSeverity::Debug};
-    }
+auto DebugLog() -> LogMessage { return LogMessage{LogSeverity::Debug}; }
 
-    LogMessage InfoLog() {
-        return {LogSeverity::Info};
-    }
+auto InfoLog() -> LogMessage { return LogMessage{LogSeverity::Info}; }
 
-    LogMessage WarningLog() {
-        return {LogSeverity::Warning};
-    }
+auto WarningLog() -> LogMessage { return LogMessage{LogSeverity::Warning}; }
 
-    LogMessage ErrorLog() {
-        return {LogSeverity::Error};
-    }
+auto ErrorLog() -> LogMessage { return LogMessage{LogSeverity::Error}; }
 
-    LogMessage DebugLog(const char* file, const char* function, int line) {
-        LogMessage message = DebugLog();
-        message << file << ":" << line << "(" << function << ")";
-        return message;
-    }
+auto DebugLog(const char* file, const char* function, int line) -> LogMessage {
+  LogMessage message = DebugLog();
+  message << file << ":" << line << "(" << function << ")";
+  return message;
+}
 
-}  // namespace dawn
+}  // namespace probegl

--- a/cpp/modules/probe.gl/core/src/log.h
+++ b/cpp/modules/probe.gl/core/src/log.h
@@ -45,61 +45,60 @@
 // It creates a LogMessage object that isn't stored anywhere and gets its destructor called
 // immediately which outputs the stored ostringstream in the right place.
 //
-// This file also contains DAWN_DEBUG for "printf debugging" which works on Android and
+// This file also contains PROBEGL_DEBUG for "printf debugging" which works on Android and
 // additionally outputs the file, line and function name. Use it this way:
 //
 //   // Pepper this throughout code to get a log of the execution
-//   DAWN_DEBUG();
+//   PROBEGL_DEBUG();
 //
 //   // Get more information
-//   DAWN_DEBUG() << texture.GetFormat();
+//   PROBEGL_DEBUG() << texture.GetFormat();
 
 #include <sstream>
 
 namespace probegl {
 
-    // Log levels mostly used to signal intent where the log message is produced and used to route
-    // the message to the correct output.
-    enum class LogSeverity {
-        Debug,
-        Info,
-        Warning,
-        Error,
-    };
+// Log levels mostly used to signal intent where the log message is produced and used to route
+// the message to the correct output.
+enum class LogSeverity {
+  Debug,
+  Info,
+  Warning,
+  Error,
+};
 
-    // Essentially an ostringstream that will print itself in its destructor.
-    class LogMessage {
-      public:
-        LogMessage(LogSeverity severity);
-        ~LogMessage();
+// Essentially an ostringstream that will print itself in its destructor.
+class LogMessage {
+ public:
+  explicit LogMessage(LogSeverity severity);
+  ~LogMessage();
 
-        LogMessage(LogMessage&& other) = default;
-        LogMessage& operator=(LogMessage&& other) = default;
+  LogMessage(LogMessage&& other) = default;
+  auto operator=(LogMessage&& other) -> LogMessage& = default;
 
-        template <typename T>
-        LogMessage& operator<<(T&& value) {
-            mStream << value;
-            return *this;
-        }
+  template <typename T>
+  auto operator<<(T&& value) -> LogMessage& {
+    mStream << value;
+    return *this;
+  }
 
-      private:
-        LogMessage(const LogMessage& other) = delete;
-        LogMessage& operator=(const LogMessage& other) = delete;
+ private:
+  LogMessage(const LogMessage& other) = delete;
+  auto operator=(const LogMessage& other) -> LogMessage& = delete;
 
-        LogSeverity mSeverity;
-        std::ostringstream mStream;
-    };
+  LogSeverity mSeverity;
+  std::ostringstream mStream;
+};
 
-    // Short-hands to create a LogMessage with the respective severity.
-    LogMessage DebugLog();
-    LogMessage InfoLog();
-    LogMessage WarningLog();
-    LogMessage ErrorLog();
+// Short-hands to create a LogMessage with the respective severity.
+auto DebugLog() -> LogMessage;
+auto InfoLog() -> LogMessage;
+auto WarningLog() -> LogMessage;
+auto ErrorLog() -> LogMessage;
 
-    // DAWN_DEBUG is a helper macro that creates a DebugLog and outputs file/line/function
-    // information
-    LogMessage DebugLog(const char* file, const char* function, int line);
-#define DAWN_DEBUG() ::probegl::DebugLog(__FILE__, __func__, __LINE__)
+// PROBEGL_DEBUG is a helper macro that creates a DebugLog and outputs file/line/function information
+auto DebugLog(const char* file, const char* function, int line) -> LogMessage;
+#define PROBEGL_DEBUG() ::probegl::DebugLog(__FILE__, __func__, __LINE__)
 
 }  // namespace probegl
 

--- a/cpp/modules/probe.gl/core/src/platform.h
+++ b/cpp/modules/probe.gl/core/src/platform.h
@@ -25,45 +25,44 @@
 #define PROBEGL_PLATFORM_H_
 
 #if defined(_WIN32) || defined(_WIN64)
-# define PROBEGL_PLATFORM_WINDOWS 1
+#define PROBEGL_PLATFORM_WINDOWS 1
 
 #elif defined(__linux__)
-# define PROBEGL_PLATFORM_LINUX 1
-# define PROBEGL_PLATFORM_POSIX 1
-# if defined(__ANDROID__)
-#  define PROBEGL_PLATFORM_ANDROID 1
-# endif
-
-#elif defined(__APPLE__)
-# define PROBEGL_PLATFORM_APPLE 1
-# define PROBEGL_PLATFORM_POSIX 1
-# include <TargetConditionals.h>
-# if TARGET_OS_IPHONE
-#  define PROBEGL_PLATFORM_IOS
-# elif TARGET_OS_MAC
-#  define PROBEGL_PLATFORM_MACOS
-# else
-#  error "Unsupported Apple platform."
-# endif
-
-#elif defined(__Fuchsia__)
-# define PROBEGL_PLATFORM_FUCHSIA 1
-# define PROBEGL_PLATFORM_POSIX 1
-
-#else
-# error "Unsupported platform."
+#define PROBEGL_PLATFORM_LINUX 1
+#define PROBEGL_PLATFORM_POSIX 1
+#if defined(__ANDROID__)
+#define PROBEGL_PLATFORM_ANDROID 1
 #endif
 
-#if defined(_WIN64) || defined(__aarch64__) || defined(__x86_64__) || defined(__mips64__) || \
-    defined(__s390x__) || defined(__PPC64__)
-# define PROBEGL_PLATFORM_64_BIT 1
+#elif defined(__APPLE__)
+#define PROBEGL_PLATFORM_APPLE 1
+#define PROBEGL_PLATFORM_POSIX 1
+#include <TargetConditionals.h>
+#if TARGET_OS_IPHONE
+#define PROBEGL_PLATFORM_IOS
+#elif TARGET_OS_MAC
+#define PROBEGL_PLATFORM_MACOS
+#else
+#error "Unsupported Apple platform."
+#endif
+
+#elif defined(__Fuchsia__)
+#define PROBEGL_PLATFORM_FUCHSIA 1
+#define PROBEGL_PLATFORM_POSIX 1
+
+#else
+#error "Unsupported platform."
+#endif
+
+#if defined(_WIN64) || defined(__aarch64__) || defined(__x86_64__) || defined(__mips64__) || defined(__s390x__) || \
+    defined(__PPC64__)
+#define PROBEGL_PLATFORM_64_BIT 1
 static_assert(sizeof(sizeof(char)) == 8, "Expect sizeof(size_t) == 8");
-#elif defined(_WIN32) || defined(__arm__) || defined(__i386__) || defined(__mips32__) || \
-    defined(__s390__)
-# define PROBEGL_PLATFORM_32_BIT 1
+#elif defined(_WIN32) || defined(__arm__) || defined(__i386__) || defined(__mips32__) || defined(__s390__)
+#define PROBEGL_PLATFORM_32_BIT 1
 static_assert(sizeof(sizeof(char)) == 4, "Expect sizeof(size_t) == 4");
 #else
-# error "Unsupported platform"
+#error "Unsupported platform"
 #endif
 
 #endif  // PROBEGL_PLATFORM_H_

--- a/cpp/modules/probe.gl/core/src/system-utils.cpp
+++ b/cpp/modules/probe.gl/core/src/system-utils.cpp
@@ -22,28 +22,27 @@
 // Copyright 2017 The Dawn Authors http://www.apache.org/licenses/LICENSE-2.0
 
 #include "./system-utils.h"  // NOLINT(build/include)
+
 #include "./platform.h"
 
 #if defined(PROBEGL_PLATFORM_WINDOWS)
-# include <Windows.h>
+#include <Windows.h>
 #elif defined(PROBEGL_PLATFORM_POSIX)
-# include <unistd.h>
+#include <unistd.h>
 #else
-# error "Unsupported platform."
+#error "Unsupported platform."
 #endif
 
 using namespace probegl;
 
 #if defined(PROBGL_PLATFORM_WINDOWS)
 
-void uSleep(unsigned int usecs) {
-  Sleep(static_cast<DWORD>(usecs / 1000));
-}
+void uSleep(unsigned int usecs) { Sleep(static_cast<DWORD>(usecs / 1000)); }
 
-#elif defined(PROBGL_PLATFORM_POSIX)
-void uSleep(unsigned int usecs) {
-  usleep(usecs);
-}
+#elif defined(PROBEGL_PLATFORM_POSIX)
+
+void uSleep(unsigned int usecs) { usleep(usecs); }
+
 #else
-# error "Implement uSleep for your platform."
+#error "Implement uSleep for your platform."
 #endif

--- a/cpp/modules/probe.gl/core/src/system-utils.h
+++ b/cpp/modules/probe.gl/core/src/system-utils.h
@@ -28,6 +28,6 @@ namespace probegl {
 
 void uSleep(unsigned int usecs);
 
-} // namespace probegl
+}  // namespace probegl
 
 #endif  // PROBEGL_SYSTEMUTILS_H_


### PR DESCRIPTION
- Cleaning up internal utility and extra helpers from `dawn` and using them to build out the C++ port of probe.gl .