### PR TITLE
animometer segfault fixed

### DIFF
--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
@@ -79,7 +79,7 @@ wgpu::TextureFormat GLFWAnimationLoop::getPreferredSwapChainTextureFormat() {
 void GLFWAnimationLoop::_initializeGLFW(wgpu::BackendType backendType) {
   // Set up an error logging callback
   glfwSetErrorCallback([](int code, const char* message) {
-    // dawn::ErrorLog() << "GLFW error: " << code << " - " << message;
+     probegl::ErrorLog() << "GLFW error: " << code << " - " << message;
   });
 
   // Init the library
@@ -106,13 +106,13 @@ void GLFWAnimationLoop::_initializeGLFW(wgpu::BackendType backendType) {
 uint64_t GLFWAnimationLoop::_getSwapChainImplementation() { return this->_binding->GetSwapChainImplementation(); }
 
 auto GLFWAnimationLoop::_createCppDawnDevice(wgpu::BackendType backendType) -> wgpu::Device {
-  auto instance = std::make_unique<dawn_native::Instance>();
-  DiscoverAdapter(instance.get(), this->window, backendType);
+  this->_instance = std::make_unique<dawn_native::Instance>();
+  DiscoverAdapter(this->_instance.get(), this->window, backendType);
 
   // Get an adapter for the backend to use, and create the device.
   dawn_native::Adapter backendAdapter;
   {
-    std::vector<dawn_native::Adapter> adapters = instance->GetAdapters();
+    std::vector<dawn_native::Adapter> adapters = this->_instance->GetAdapters();
     auto adapterIt = std::find_if(adapters.begin(), adapters.end(), [=](const dawn_native::Adapter adapter) -> bool {
       wgpu::AdapterProperties properties;
       adapter.GetProperties(&properties);

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
@@ -50,6 +50,7 @@ class GLFWAnimationLoop : public AnimationLoop {
   auto _createCppDawnDevice(wgpu::BackendType backendType) -> wgpu::Device;
   auto _createDefaultDepthStencilView(const wgpu::Device& device) -> wgpu::TextureView;
 
+  std::unique_ptr<dawn_native::Instance> _instance;
   utils::BackendBinding* _binding{nullptr};
 
   dawn_wire::WireServer* _wireServer{nullptr};

--- a/cpp/modules/luma.gl/webgpu/src/terrible-command-buffer.h
+++ b/cpp/modules/luma.gl/webgpu/src/terrible-command-buffer.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef UTILS_TERRIBLE_COMMAND_BUFFER_H_
-#define UTILS_TERRIBLE_COMMAND_BUFFER_H_
+#ifndef LUMAGL_WEBGPU_TERRIBLE_COMMAND_BUFFER_H
+#define LUMAGL_WEBGPU_TERRIBLE_COMMAND_BUFFER_H
 
 #include <vector>
 
@@ -45,4 +45,4 @@ class TerribleCommandBuffer : public dawn_wire::CommandSerializer {
 }  // namespace utils
 }  // namespace lumagl
 
-#endif  // UTILS_TERRIBLE_COMMAND_BUFFER_H_
+#endif  // LUMAGL_WEBGPU_TERRIBLE_COMMAND_BUFFER_H

--- a/cpp/modules/luma.gl/webgpu/src/webgpu-utils.cpp
+++ b/cpp/modules/luma.gl/webgpu/src/webgpu-utils.cpp
@@ -37,7 +37,6 @@ auto getDefaultWebGPUBackendType() -> wgpu::BackendType {
 #elif defined(LUMAGL_ENABLE_BACKEND_OPENGL)
   return wgpu::BackendType::OpenGL;
 #else
-#warning "No LUMAGL_ENABLE_BACKEND_ constant set"
   return wgpu::BackendType::Null;
 #endif
 }


### PR DESCRIPTION
Debugger led me down the wrong path for a while there, turned out to be a simple fix that we have to keep Instance around even after setup is done. The example seems to run fine all the time now.

Will move onto revisiting luma API next and getting rid of unnecessary pieces.

@ibgreen I tried running the example using OpenGL backend instead of Metal and it crashed immediately, just out of curiosity, is it supposed to run on Mac?