### PR TITLE
Instanced attribute support

### DIFF
--- a/cpp/examples/luma.gl/animometer.cc
+++ b/cpp/examples/luma.gl/animometer.cc
@@ -133,7 +133,8 @@ int main(int argc, const char* argv[]) {
   wgpu::Device device = *(animationLoop.device.get());
 
   auto attributes = createAttributeTable(device);
-  Model model{device, {vs, fs, attributes->schema(), nullptr, {{sizeof(ShaderData)}}}};
+  auto instancedSchema = std::make_shared<garrow::Schema>(std::vector<std::shared_ptr<garrow::Field>>{});
+  Model model{device, {vs, fs, attributes->schema(), instancedSchema, {{sizeof(ShaderData)}}}};
 
   std::vector<ShaderData> shaderData = createSampleData(kNumTriangles);
   std::vector<wgpu::Buffer> uniformBuffers;

--- a/cpp/examples/luma.gl/animometer.cc
+++ b/cpp/examples/luma.gl/animometer.cc
@@ -133,7 +133,7 @@ int main(int argc, const char* argv[]) {
   wgpu::Device device = *(animationLoop.device.get());
 
   auto attributes = createAttributeTable(device);
-  Model model{animationLoop.device, {vs, fs, attributes->schema(), {{sizeof(ShaderData)}}}};
+  Model model{device, {vs, fs, attributes->schema(), nullptr, {{sizeof(ShaderData)}}}};
 
   std::vector<ShaderData> shaderData = createSampleData(kNumTriangles);
   std::vector<wgpu::Buffer> uniformBuffers;

--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -67,7 +67,7 @@ Deck::Deck(std::shared_ptr<Deck::Props> props)
 }
 
 Deck::~Deck() {
-  this->animationLoop->running = false;
+  this->animationLoop->stop();
   // this->tooltip.remove();
 }
 

--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -58,19 +58,16 @@ auto Deck::Props::getProperties() const -> const Properties* {
 // Deck class
 
 Deck::Deck(std::shared_ptr<Deck::Props> props)
-    : Component(props),
-      width{100},
-      height{100},
-      viewManager{std::make_shared<ViewManager>()},
-      // layerManager{std::make_shared<LayerManager>()},
-      _needsRedraw{"Initial render"} {
-  // this->animationLoop = this->_createAnimationLoop(props);
+    : Component(props), width{props->width}, height{props->height}, _needsRedraw{"Initial render"} {
   this->setProps(props.get());
-  // this->animationLoop.start();
+  this->animationLoop = this->_createAnimationLoop(props);
+  animationLoop->run([&](wgpu::RenderPassEncoder pass) {
+    // TODO(ilija@unfolded.ai): Do we tell LayerManager to redraw the layers here?
+  });
 }
 
 Deck::~Deck() {
-  // this->animationLoop.stop();
+  this->animationLoop->running = false;
   // this->tooltip.remove();
 }
 
@@ -163,6 +160,27 @@ void Deck::redraw(bool force) {
   // } else {
   this->_drawLayers(redrawReason);
   // }
+  */
+}
+
+auto Deck::_createAnimationLoop(const std::shared_ptr<Deck::Props>& props) -> std::shared_ptr<lumagl::AnimationLoop> {
+  return std::make_shared<lumagl::GLFWAnimationLoop>();
+
+  /*
+  const {width, height, gl, glOptions, debug, useDevicePixels, autoResizeDrawingBuffer} = props;
+
+  return new AnimationLoop({
+    width,
+    height,
+    useDevicePixels,
+    autoResizeDrawingBuffer,
+    autoResizeViewport: false,
+    gl,
+    onCreateContext: opts =>
+      createGLContext(Object.assign({}, glOptions, opts, {canvas: this->canvas, debug})), onInitialize:
+this->_onRendererInitialized, onRender: this->_onRenderFrame, onBeforeRender: props->onBeforeRender, onAfterRender:
+props->onAfterRender
+  });
   */
 }
 
@@ -303,23 +321,6 @@ this->width || newHeight !== this->height) { this->width = newWidth;
     return true;
   }
   return false;
-}
-
-void Deck::_createAnimationLoop(props) {
-  const {width, height, gl, glOptions, debug, useDevicePixels, autoResizeDrawingBuffer} = props;
-
-  return new AnimationLoop({
-    width,
-    height,
-    useDevicePixels,
-    autoResizeDrawingBuffer,
-    autoResizeViewport: false,
-    gl,
-    onCreateContext: opts =>
-      createGLContext(Object.assign({}, glOptions, opts, {canvas: this->canvas, debug})), onInitialize:
-this->_onRendererInitialized, onRender: this->_onRenderFrame, onBeforeRender: props->onBeforeRender, onAfterRender:
-props->onAfterRender
-  });
 }
 
 // The `pointermove` event may fire multiple times in between two animation frames,

--- a/cpp/modules/deck.gl/core/src/lib/deck.h
+++ b/cpp/modules/deck.gl/core/src/lib/deck.h
@@ -29,6 +29,7 @@
 #include "./layer-manager.h"
 #include "./view-manager.h"
 #include "deck.gl/json.h"
+#include "luma.gl/core.h"
 
 /*
 import LayerManager from './layer-manager';
@@ -92,13 +93,15 @@ class Deck : public Component {
   auto needsRedraw(bool clearRedrawFlags = false) -> std::optional<std::string>;
   void redraw(bool force = false);
 
-  auto getViews() -> std::list<View>;  // { return this->viewManager->views; }
+  auto getViews() -> std::list<std::shared_ptr<View>> { return this->viewManager->getViews(); }
 
   // Get a set of viewports for a given width and height
   // `getViewports`(rect);
   // `pickObject`({x, y, radius = 0, layerIds = nullptr, unproject3D})
   // `pickMultipleObjects`({x, y, radius = 0, layerIds = nullptr, unproject3D, depth = 10})
   // `pickObjects`({x, y, width = 1, height = 1, layerIds = nullptr})
+
+  std::shared_ptr<lumagl::AnimationLoop> animationLoop;
 
  private:
   // Get the most relevant view state: props.viewState, if supplied, shadows internal viewState
@@ -110,7 +113,8 @@ class Deck : public Component {
   void _onRendererInitialized(void *gl);
   void _onRenderFrame();      // animationProps);
   void _onViewStateChange();  // params);
-};                            // namespace deckgl
+  auto _createAnimationLoop(const std::shared_ptr<Deck::Props> &props) -> std::shared_ptr<lumagl::AnimationLoop>;
+};
 
 class Deck::Props : public Component::Props {
  public:

--- a/cpp/modules/deck.gl/core/src/lib/layer.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/layer.cpp
@@ -325,10 +325,9 @@ void Layer::updateState(const Layer::ChangeFlags& changeFlags, const Layer::Prop
 void Layer::finalizeState() {}
 
 // If state has a model, draw it with supplied uniforms
-void Layer::drawState() {
+void Layer::drawState(wgpu::RenderPassEncoder pass) {
   for (auto model : this->getModels()) {
-    // TODO(ilija@unfolded.ai): Add render pass plumbing so that we can pass it to draw
-    //    model->draw();
+    model->draw(pass);
   }
 }
 
@@ -441,7 +440,8 @@ void Layer::finalize() {
 // Calculates uniforms
 void Layer::draw() {
   // Call subclass lifecycle method
-  this->drawState();
+  // TODO(ilija@unfolded.ai): Not sure where draw is being called from, but we need render pass reference here
+  //  this->drawState();
   // End lifecycle method
 }
 

--- a/cpp/modules/deck.gl/core/src/lib/layer.h
+++ b/cpp/modules/deck.gl/core/src/lib/layer.h
@@ -21,6 +21,8 @@
 #ifndef DECKGL_CORE_LAYER_H
 #define DECKGL_CORE_LAYER_H
 
+#include <dawn/webgpu_cpp.h>
+
 #include <exception>
 #include <functional>
 #include <iostream>
@@ -164,7 +166,7 @@ class Layer : public Component {
   virtual void finalizeState();
 
   // If state has a model, draw it with supplied uniforms
-  virtual void drawState();
+  virtual void drawState(wgpu::RenderPassEncoder pass);
 
  protected:
   // INTERNAL METHODS

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -22,13 +22,12 @@
 
 #include <arrow/builder.h>
 
-// #include "./line-layer-fragment.glsl.h"
-// #include "./line-layer-vertex.glsl.h"
+#include "./line-layer-fragment.glsl.h"
+#include "./line-layer-vertex.glsl.h"
 #include "deck.gl/core.h"
 
 using namespace deckgl;
 using namespace lumagl;
-using namespace lumagl::garrow;
 
 const std::vector<const Property*> propTypeDefs = {
     //  new PropertyT<std::string>{"widthUnits",
@@ -110,7 +109,7 @@ void LineLayer::updateState(const Layer::ChangeFlags& changeFlags, const Layer::
 
 void LineLayer::finalizeState() {}
 
-void LineLayer::drawState() {  // {uniforms}
+void LineLayer::drawState(wgpu::RenderPassEncoder pass) {  // {uniforms}
   /*
   const {viewport} = this->context;
   const {widthUnits, widthScale, widthMinPixels, widthMaxPixels} = ;
@@ -130,7 +129,22 @@ void LineLayer::drawState() {  // {uniforms}
 }
 
 auto LineLayer::_getModel(wgpu::Device device) -> std::shared_ptr<lumagl::Model> {
-  return std::shared_ptr<lumagl::Model>{nullptr};
+  auto positions = std::make_shared<garrow::Field>("positions", wgpu::VertexFormat::Float3);
+  std::vector<std::shared_ptr<garrow::Field>> attributeFields{positions};
+  auto attributeSchema = std::make_shared<lumagl::garrow::Schema>(attributeFields);
+
+  // TODO(ilija@unfolded.ai): **arrow**::Fields are already being specified in initializeState, consolidate?
+  auto sourcePosition = std::make_shared<garrow::Field>("instanceSourcePositions", wgpu::VertexFormat::Float3);
+  auto targetPosition = std::make_shared<garrow::Field>("instanceTargetPositions", wgpu::VertexFormat::Float3);
+  auto color = std::make_shared<garrow::Field>("instanceColors", wgpu::VertexFormat::Float4);
+  auto width = std::make_shared<garrow::Field>("instanceWidths", wgpu::VertexFormat::Float);
+
+  std::vector<std::shared_ptr<garrow::Field>> instancedFields{sourcePosition, targetPosition, color, width};
+  auto instancedAttributeSchema = std::make_shared<lumagl::garrow::Schema>(instancedFields);
+
+  auto modelOptions = Model::Options{vs, fs, attributeSchema, instancedAttributeSchema};
+  return std::make_shared<lumagl::Model>(device, modelOptions);
+
   //
   //  (0, -1)-------------_(1, -1)
   //       |          _,-"  |

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -129,17 +129,16 @@ void LineLayer::drawState(wgpu::RenderPassEncoder pass) {  // {uniforms}
 }
 
 auto LineLayer::_getModel(wgpu::Device device) -> std::shared_ptr<lumagl::Model> {
-  auto positions = std::make_shared<garrow::Field>("positions", wgpu::VertexFormat::Float3);
-  std::vector<std::shared_ptr<garrow::Field>> attributeFields{positions};
+  std::vector<std::shared_ptr<garrow::Field>> attributeFields{
+      std::make_shared<garrow::Field>("positions", wgpu::VertexFormat::Float3)};
   auto attributeSchema = std::make_shared<lumagl::garrow::Schema>(attributeFields);
 
   // TODO(ilija@unfolded.ai): **arrow**::Fields are already being specified in initializeState, consolidate?
-  auto sourcePosition = std::make_shared<garrow::Field>("instanceSourcePositions", wgpu::VertexFormat::Float3);
-  auto targetPosition = std::make_shared<garrow::Field>("instanceTargetPositions", wgpu::VertexFormat::Float3);
-  auto color = std::make_shared<garrow::Field>("instanceColors", wgpu::VertexFormat::Float4);
-  auto width = std::make_shared<garrow::Field>("instanceWidths", wgpu::VertexFormat::Float);
-
-  std::vector<std::shared_ptr<garrow::Field>> instancedFields{sourcePosition, targetPosition, color, width};
+  std::vector<std::shared_ptr<garrow::Field>> instancedFields{
+      std::make_shared<garrow::Field>("instanceSourcePositions", wgpu::VertexFormat::Float3),
+      std::make_shared<garrow::Field>("instanceTargetPositions", wgpu::VertexFormat::Float3),
+      std::make_shared<garrow::Field>("instanceColors", wgpu::VertexFormat::Float4),
+      std::make_shared<garrow::Field>("instanceWidths", wgpu::VertexFormat::Float)};
   auto instancedAttributeSchema = std::make_shared<lumagl::garrow::Schema>(instancedFields);
 
   auto modelOptions = Model::Options{vs, fs, attributeSchema, instancedAttributeSchema};

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
@@ -51,7 +51,7 @@ class LineLayer : public Layer {
   void initializeState() override;
   void updateState(const Layer::ChangeFlags&, const Layer::Props* oldProps) override;
   void finalizeState() override;
-  void drawState() override;
+  void drawState(wgpu::RenderPassEncoder pass) override;
 
  private:
   auto _getModel(wgpu::Device) -> std::shared_ptr<lumagl::Model>;

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
@@ -158,7 +158,7 @@ void ScatterplotLayer::updateState(const Layer::ChangeFlags& changeFlags, const 
 
 void ScatterplotLayer::finalizeState() {}
 
-void ScatterplotLayer::drawState() {  // uniforms
+void ScatterplotLayer::drawState(wgpu::RenderPassEncoder pass) {  // uniforms
   /*
     const {viewport} = this->context;
     const {

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
@@ -50,7 +50,7 @@ class ScatterplotLayer : public Layer {
   void initializeState() override;
   void updateState(const ChangeFlags&, const Layer::Props* oldProps) override;
   void finalizeState() override;
-  void drawState() override;
+  void drawState(wgpu::RenderPassEncoder pass) override;
 
  private:
   // TODO(ilija@unfolded.ai): Is there a way to avoid passing device here?

--- a/cpp/modules/luma.gl/core/src/animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/animation-loop.cpp
@@ -35,9 +35,9 @@ AnimationLoop::~AnimationLoop() {
 }
 
 void AnimationLoop::setSize(int width, int height) {
-  bool sizeChanged = width != this->width || height != this->height;
-  this->width = width;
-  this->height = height;
+  bool sizeChanged = width != this->_width || height != this->_height;
+  this->_width = width;
+  this->_height = height;
 
   if (sizeChanged) {
     this->swapchain = this->_createSwapchain(this->device);
@@ -94,6 +94,4 @@ void AnimationLoop::_initialize(const wgpu::BackendType backendType, std::shared
   this->device = device;
   this->queue = this->device->CreateQueue();
   this->swapchain = this->_createSwapchain(this->device);
-
-  this->setSize(width, height);
 }

--- a/cpp/modules/luma.gl/core/src/animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/animation-loop.cpp
@@ -34,12 +34,10 @@ AnimationLoop::~AnimationLoop() {
   // TODO(ilija@unfolded.ai): Cleanup?
 }
 
-void AnimationLoop::setSize(int width, int height) {
-  bool sizeChanged = width != this->_width || height != this->_height;
-  this->_width = width;
-  this->_height = height;
-
+void AnimationLoop::setSize(const Size& size) {
+  bool sizeChanged = size.width != this->_size.width || size.height != this->_size.height;
   if (sizeChanged) {
+    this->_size = size;
     this->swapchain = this->_createSwapchain(this->device);
     // TODO(ilija@unfolded.ai): Trigger redraw
   }

--- a/cpp/modules/luma.gl/core/src/animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/animation-loop.h
@@ -28,12 +28,21 @@
 
 namespace lumagl {
 
+struct Size {
+ public:
+  Size(int width, int height) : width{width}, height{height} {}
+
+  int width;
+  int height;
+};
+
 class AnimationLoop {
  public:
-  AnimationLoop(int width, int height) : _width{width}, _height{height} {}
+  explicit AnimationLoop(const Size& size = Size{640, 480}) : _size{size} {}
   virtual ~AnimationLoop();
 
-  void setSize(int width, int height);
+  auto size() -> Size { return this->_size; };
+  void setSize(const Size& size);
 
   virtual void run(std::function<void(wgpu::RenderPassEncoder)> onRender);
   virtual void frame(std::function<void(wgpu::RenderPassEncoder)> onRender);
@@ -55,8 +64,7 @@ class AnimationLoop {
   virtual auto _createDevice(const wgpu::BackendType backendType) -> std::unique_ptr<wgpu::Device> = 0;
   virtual auto _createSwapchain(std::shared_ptr<wgpu::Device> device) -> wgpu::SwapChain = 0;
 
-  int _width{640};
-  int _height{480};
+  Size _size;
 };
 
 }  // namespace lumagl

--- a/cpp/modules/luma.gl/core/src/animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/animation-loop.h
@@ -30,6 +30,7 @@ namespace lumagl {
 
 class AnimationLoop {
  public:
+  AnimationLoop(int width, int height) : _width{width}, _height{height} {}
   virtual ~AnimationLoop();
 
   void setSize(int width, int height);
@@ -42,22 +43,20 @@ class AnimationLoop {
   virtual void flush() {}
   virtual auto getPreferredSwapChainTextureFormat() -> wgpu::TextureFormat { return wgpu::TextureFormat::Undefined; };
 
-  // TODO(ilija@unfolded.ai): Make these read-only?
-  int width{640};
-  int height{480};
-
   // Internal, but left public to facilitate integration
   std::shared_ptr<wgpu::Device> device;
   wgpu::Queue queue;
   wgpu::SwapChain swapchain;
 
-  // TODO(ilija@unfolded.ai): Make this read-only?
   bool running{false};
 
  protected:
   void _initialize(const wgpu::BackendType backendType, std::shared_ptr<wgpu::Device> device);
   virtual auto _createDevice(const wgpu::BackendType backendType) -> std::unique_ptr<wgpu::Device> = 0;
   virtual auto _createSwapchain(std::shared_ptr<wgpu::Device> device) -> wgpu::SwapChain = 0;
+
+  int _width{640};
+  int _height{480};
 };
 
 }  // namespace lumagl

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
@@ -40,7 +40,9 @@
 using namespace lumagl;
 using namespace lumagl::utils;
 
-GLFWAnimationLoop::GLFWAnimationLoop(const wgpu::BackendType backendType, std::shared_ptr<wgpu::Device> device) {
+GLFWAnimationLoop::GLFWAnimationLoop(const wgpu::BackendType backendType, std::shared_ptr<wgpu::Device> device,
+                                     int width, int height)
+    : AnimationLoop(width, height) {
   this->_window = this->_initializeGLFW(backendType);
 
   // Create a device if none was provided
@@ -110,8 +112,8 @@ auto GLFWAnimationLoop::_createSwapchain(std::shared_ptr<wgpu::Device> device) -
   wgpu::SwapChainDescriptor swapChainDesc;
   swapChainDesc.implementation = this->_binding->GetSwapChainImplementation();
   auto swapchain = device->CreateSwapChain(nullptr, &swapChainDesc);
-  swapchain.Configure(this->getPreferredSwapChainTextureFormat(), wgpu::TextureUsage::OutputAttachment, this->width,
-                      this->height);
+  swapchain.Configure(this->getPreferredSwapChainTextureFormat(), wgpu::TextureUsage::OutputAttachment, this->_width,
+                      this->_height);
 
   return swapchain;
 }
@@ -141,7 +143,7 @@ auto GLFWAnimationLoop::_initializeGLFW(const wgpu::BackendType backendType) -> 
       glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
   }
 
-  auto window = glfwCreateWindow(this->width, this->height, "deck.gl window", nullptr, nullptr);
+  auto window = glfwCreateWindow(this->_width, this->_height, "deck.gl window", nullptr, nullptr);
   if (!window) {
     throw new std::runtime_error("Failed to create GLFW window");
   }

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
@@ -41,8 +41,8 @@ using namespace lumagl;
 using namespace lumagl::utils;
 
 GLFWAnimationLoop::GLFWAnimationLoop(const wgpu::BackendType backendType, std::shared_ptr<wgpu::Device> device,
-                                     int width, int height)
-    : AnimationLoop(width, height) {
+                                     const Size& size)
+    : AnimationLoop{size} {
   this->_window = this->_initializeGLFW(backendType);
 
   // Create a device if none was provided
@@ -112,8 +112,8 @@ auto GLFWAnimationLoop::_createSwapchain(std::shared_ptr<wgpu::Device> device) -
   wgpu::SwapChainDescriptor swapChainDesc;
   swapChainDesc.implementation = this->_binding->GetSwapChainImplementation();
   auto swapchain = device->CreateSwapChain(nullptr, &swapChainDesc);
-  swapchain.Configure(this->getPreferredSwapChainTextureFormat(), wgpu::TextureUsage::OutputAttachment, this->_width,
-                      this->_height);
+  swapchain.Configure(this->getPreferredSwapChainTextureFormat(), wgpu::TextureUsage::OutputAttachment,
+                      this->_size.width, this->_size.height);
 
   return swapchain;
 }
@@ -143,7 +143,7 @@ auto GLFWAnimationLoop::_initializeGLFW(const wgpu::BackendType backendType) -> 
       glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
   }
 
-  auto window = glfwCreateWindow(this->_width, this->_height, "deck.gl window", nullptr, nullptr);
+  auto window = glfwCreateWindow(this->_size.width, this->_size.height, "deck.gl window", nullptr, nullptr);
   if (!window) {
     throw new std::runtime_error("Failed to create GLFW window");
   }

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
@@ -34,7 +34,7 @@ namespace lumagl {
 class GLFWAnimationLoop : public AnimationLoop {
  public:
   GLFWAnimationLoop(const wgpu::BackendType backendType = utils::getDefaultWebGPUBackendType(),
-                    std::shared_ptr<wgpu::Device> device = nullptr, int width = 640, int height = 480);
+                    std::shared_ptr<wgpu::Device> device = nullptr, const Size& size = Size{640, 480});
   ~GLFWAnimationLoop();
 
   void frame(std::function<void(wgpu::RenderPassEncoder)> onRender) override;

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
@@ -34,7 +34,7 @@ namespace lumagl {
 class GLFWAnimationLoop : public AnimationLoop {
  public:
   GLFWAnimationLoop(const wgpu::BackendType backendType = utils::getDefaultWebGPUBackendType(),
-                    std::shared_ptr<wgpu::Device> device = nullptr);
+                    std::shared_ptr<wgpu::Device> device = nullptr, int width = 640, int height = 480);
   ~GLFWAnimationLoop();
 
   void frame(std::function<void(wgpu::RenderPassEncoder)> onRender) override;

--- a/cpp/modules/luma.gl/core/src/model.h
+++ b/cpp/modules/luma.gl/core/src/model.h
@@ -32,24 +32,30 @@
 
 namespace lumagl {
 
+/// \brief Collection of keys that provide additional attribute context when present in input scheme metadata.
+// TODO(ilija@unfolded.ai): Document metadata properties and the behavior they trigger once we finalize the list
+struct AttributePropertyKeys {
+ public:
+  /// \brief Determines whether attribute step mode will be instanced or vertex.
+  static const char* IS_INSTANCED;
+};
+
 // TODO(ilija@unfolded.ai): Move out and revisit
 struct UniformDescriptor {
   size_t elementSize;
   bool isDynamic{false};
 };
 
-/// \brief Holds shaders compiled and linked into a pipeline
+/// \brief Holds shaders compiled and linked into a pipeline.
 class Model {
  public:
   class Options;
 
-  /// \brief construct a new Model
-  explicit Model(std::shared_ptr<wgpu::Device> device, const Options&);
-
-  // TODO(ilija@unfolded.ai): Remove once integration is complete and layers provide valid options
-  explicit Model(std::shared_ptr<wgpu::Device> device);
+  /// \brief construct a new Model.
+  Model(wgpu::Device device, const Options&);
 
   void setAttributes(const std::shared_ptr<garrow::Table>& attributes);
+  void setInstancedAttributes(const std::shared_ptr<garrow::Table>& attributes);
   void setUniformBuffers(const std::vector<wgpu::Buffer>& uniforms);
 
   void draw(wgpu::RenderPassEncoder pass);
@@ -68,23 +74,34 @@ class Model {
   wgpu::ShaderModule fsModule;
 
  private:
-  std::shared_ptr<wgpu::Device> _device;
+  wgpu::Device _device;
   std::shared_ptr<garrow::Table> _attributeTable;
+  std::shared_ptr<garrow::Table> _instancedAttributeTable;
   std::vector<UniformDescriptor> _uniforms;
 
-  void _initializeVertexState(utils::ComboVertexStateDescriptor&, const std::shared_ptr<garrow::Schema>&);
+  void _initializeVertexState(utils::ComboVertexStateDescriptor* descriptor,
+                              const std::shared_ptr<garrow::Schema>& attributeSchema,
+                              const std::shared_ptr<garrow::Schema>& instancedAttributeSchema);
   auto _createBindGroupLayout(wgpu::Device device, const std::vector<UniformDescriptor>& uniforms)
       -> wgpu::BindGroupLayout;
 
   void _setVertexBuffers(wgpu::RenderPassEncoder pass);
+
+  auto _getInputStepMode(const std::shared_ptr<garrow::Field>& field) -> wgpu::InputStepMode;
 };
 
 class Model::Options {
  public:
   Options(const std::string& vs, const std::string& fs, const std::shared_ptr<garrow::Schema>& attributeSchema,
+          const std::shared_ptr<garrow::Schema>& instancedAttributeSchema = nullptr,
           const std::vector<UniformDescriptor>& uniforms = {},
           const wgpu::TextureFormat& textureFormat = static_cast<wgpu::TextureFormat>(WGPUTextureFormat_BGRA8Unorm))
-      : vs{vs}, fs{fs}, attributeSchema{attributeSchema}, uniforms{uniforms}, textureFormat{textureFormat} {}
+      : vs{vs},
+        fs{fs},
+        attributeSchema{attributeSchema},
+        instancedAttributeSchema{instancedAttributeSchema},
+        uniforms{uniforms},
+        textureFormat{textureFormat} {}
 
   /// \brief Vertex shader source.
   std::string vs;
@@ -92,6 +109,8 @@ class Model::Options {
   std::string fs;
   /// \brief Attribute definitions.
   const std::shared_ptr<garrow::Schema> attributeSchema;
+  /// \brief Instanced attribute definitions.
+  const std::shared_ptr<garrow::Schema>& instancedAttributeSchema;
   /// \brief Uniform definitions.
   const std::vector<UniformDescriptor> uniforms;
   /// \brief Texture format that the pipeline will use.

--- a/cpp/modules/luma.gl/core/src/model.h
+++ b/cpp/modules/luma.gl/core/src/model.h
@@ -34,11 +34,7 @@ namespace lumagl {
 
 /// \brief Collection of keys that provide additional attribute context when present in input scheme metadata.
 // TODO(ilija@unfolded.ai): Document metadata properties and the behavior they trigger once we finalize the list
-struct AttributePropertyKeys {
- public:
-  /// \brief Determines whether attribute step mode will be instanced or vertex.
-  static const char* IS_INSTANCED;
-};
+struct AttributePropertyKeys {};
 
 // TODO(ilija@unfolded.ai): Move out and revisit
 struct UniformDescriptor {
@@ -59,6 +55,8 @@ class Model {
   void setUniformBuffers(const std::vector<wgpu::Buffer>& uniforms);
 
   void draw(wgpu::RenderPassEncoder pass);
+
+  auto device() -> wgpu::Device { return this->_device; }
 
   int vertexCount;
 
@@ -86,14 +84,13 @@ class Model {
       -> wgpu::BindGroupLayout;
 
   void _setVertexBuffers(wgpu::RenderPassEncoder pass);
-
-  auto _getInputStepMode(const std::shared_ptr<garrow::Field>& field) -> wgpu::InputStepMode;
 };
 
 class Model::Options {
  public:
   Options(const std::string& vs, const std::string& fs, const std::shared_ptr<garrow::Schema>& attributeSchema,
-          const std::shared_ptr<garrow::Schema>& instancedAttributeSchema = nullptr,
+          const std::shared_ptr<garrow::Schema>& instancedAttributeSchema =
+              std::make_shared<garrow::Schema>(std::vector<std::shared_ptr<garrow::Field>>{}),
           const std::vector<UniformDescriptor>& uniforms = {},
           const wgpu::TextureFormat& textureFormat = static_cast<wgpu::TextureFormat>(WGPUTextureFormat_BGRA8Unorm))
       : vs{vs},
@@ -110,7 +107,7 @@ class Model::Options {
   /// \brief Attribute definitions.
   const std::shared_ptr<garrow::Schema> attributeSchema;
   /// \brief Instanced attribute definitions.
-  const std::shared_ptr<garrow::Schema>& instancedAttributeSchema;
+  const std::shared_ptr<garrow::Schema> instancedAttributeSchema;
   /// \brief Uniform definitions.
   const std::vector<UniformDescriptor> uniforms;
   /// \brief Texture format that the pipeline will use.

--- a/cpp/modules/luma.gl/garrow/src/table.h
+++ b/cpp/modules/luma.gl/garrow/src/table.h
@@ -34,7 +34,8 @@ namespace garrow {
 /// \brief GPU memory table whos columns represent in-memory buffers.
 class Table {
  public:
-  Table(const std::shared_ptr<Schema>& schema, const std::vector<std::shared_ptr<Array>> arrays)
+  // TODO(ilija@unfolded.ai): Arrow uses static Make functions to instantiate the Table, revisit?
+  Table(const std::shared_ptr<Schema>& schema, const std::vector<std::shared_ptr<Array>>& arrays)
       : _schema{schema}, _columns{arrays} {}
 
   /// \brief Returns schema that describes this table.


### PR DESCRIPTION
Initial take on instanced attributes and layer integration.

I tried going over the entire hierarchy of `Deck`, `LayerManager`, `Layer` in order to pick out what we'd need for the initial version, but it's pretty confusing for me as I'm not sure which pieces can be left out. Ideally we go through this together and mock the API for the initial release.

One obvious thing that's done half and half right now is the way instanced attributes are specified. I initially went with 2 schema/table approach, but perhaps we can use a single schema/table with appropriate metadata field set, as shown in the current implementation?

Two minor things that I could use some input on:
- Should any of attribute tables be considered "required"? I'm asking this in order to establish what kind of default values should be provided. Currently instanced attribute schema has `nullptr` as default value, but we likely want to have an empty schema if not using it is a common use case
- As metadata supports string keys/values only, we likely want to define how different types should be passed, ie. boolean and potentially more complex types (don't think we'll have any?)