### PR TITLE
[WIP] Flight paths debug progress

### DIFF
--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -118,6 +118,10 @@ void Deck::run() {
       for (auto const& layer : this->layerManager->layers) {
         // TODO(ilija@unfolded.ai): Pass relevant layer properties to getUniformsFromViewport
         auto viewportUniforms = getUniformsFromViewport(viewport);
+
+        // TODO(ilija@unfolded.ai): Remove and use row_major specifier in uniform layout once drawing works
+        viewportUniforms.viewProjectionMatrix = viewportUniforms.viewProjectionMatrix.Transpose();
+
         auto uniformArray = std::make_shared<lumagl::garrow::Array>(this->context->device, &viewportUniforms, 1,
                                                                     wgpu::BufferUsage::Uniform);
         for (auto const& model : layer->getModels()) {

--- a/cpp/modules/deck.gl/core/src/shaderlib/project/viewport-uniforms.cpp
+++ b/cpp/modules/deck.gl/core/src/shaderlib/project/viewport-uniforms.cpp
@@ -118,8 +118,7 @@ auto calculateMatrixAndOffset(const std::shared_ptr<Viewport>& viewport, COORDIN
     cameraPosCommon = cameraPosCommon - positionCommonSpace3;
 
     auto positionCommonSpace = Vector4<double>(positionCommonSpace3, 1);
-
-    projectionCenter = viewProjectionMatrix.transform(positionCommonSpace);
+    projectionCenter = positionCommonSpace.transform(viewProjectionMatrix);
 
     // Always apply uncentered projection matrix if available (shader adds center)
     // TODO(isaac@unfolded.ai): elided default of viewport.viewMatrix

--- a/cpp/modules/deck.gl/core/src/shaderlib/project/viewport-uniforms.h
+++ b/cpp/modules/deck.gl/core/src/shaderlib/project/viewport-uniforms.h
@@ -30,24 +30,27 @@
 
 namespace deckgl {
 
-// NOTE: When using std140 memory layout in GLSL, vec3 is 16byte aligned, hence the alignas
+/// Uniform buffers use std140 memory layout, which makes vec3 16-byte aligned.
+/// The order of fields in this structure is crucial for it to be mapped to its GLSL counterpart properly.
+/// The current order is the most efficient representation of this structure. For more details on layout blocks, see:
+/// https://learnopengl.com/Advanced-OpenGL/Advanced-GLSL
 struct ViewportUniforms {
-  int32_t coordinateSystem;
-  int32_t projectionMode;
-  float scale;
-  bool wrapLongitude;
-  float antimeridian;
-  alignas(16) mathgl::Vector3<float> commonUnitsPerMeter;
-  alignas(16) mathgl::Vector3<float> commonUnitsPerWorldUnit;
-  alignas(16) mathgl::Vector3<float> commonUnitsPerWorldUnit2;
-  mathgl::Vector4<float> center;
   mathgl::Matrix4<float> modelMatrix;
   mathgl::Matrix4<float> viewProjectionMatrix;
-  mathgl::Vector2<float> viewportSize;
-  float devicePixelRatio;
-  float focalDistance;
+  mathgl::Vector4<float> center;
+  alignas(16) mathgl::Vector3<float> commonUnitsPerMeter;
+  int32_t coordinateSystem;
+  alignas(16) mathgl::Vector3<float> commonUnitsPerWorldUnit;
+  int32_t projectionMode;
+  alignas(16) mathgl::Vector3<float> commonUnitsPerWorldUnit2;
+  float scale;
   alignas(16) mathgl::Vector3<float> cameraPosition;
+  float antimeridian;
   alignas(16) mathgl::Vector3<float> coordinateOrigin;
+  float devicePixelRatio;
+  mathgl::Vector2<float> viewportSize;
+  float focalDistance;
+  alignas(4) bool wrapLongitude;
 };
 
 /**

--- a/cpp/modules/deck.gl/core/src/viewports/viewport.cpp
+++ b/cpp/modules/deck.gl/core/src/viewports/viewport.cpp
@@ -32,6 +32,7 @@ Viewport::Viewport(const string& id, const ViewMatrixOptions& viewMatrixOptions,
     : id{id}, x{x}, y{y}, width{width}, height{height} {
   this->_initViewMatrix(viewMatrixOptions);
   this->_initProjectionMatrix(projectionMatrixOptions);
+  this->_initPixelMatrices();
 }
 
 auto Viewport::metersPerPixel() -> double { return this->distanceScales.metersPerUnit.z / this->scale; }
@@ -110,20 +111,11 @@ auto Viewport::getCameraDirection() -> mathgl::Vector3<double> { return this->ca
 
 auto Viewport::getCameraUp() -> mathgl::Vector3<double> { return this->cameraUp; }
 
-auto Viewport::_getCenterInWorld(const mathgl::Vector2<double>& lngLat) -> mathgl::Vector3<double> {
-  // Make a centered version of the matrix for projection modes without an offset
-  auto center2d = this->projectFlat(lngLat);
-  auto center = Vector3<double>(center2d, 0);
-
-  // elided
-  // if (meterOffset) {
-  //   const commonPosition = new Vector3(meterOffset)
-  //     // Convert to pixels in current zoom
-  //     .scale(distanceScales.unitsPerMeter);
-  //   center.add(commonPosition);
-  // }
-
-  return center;
+auto Viewport::_createProjectionMatrix(bool orthographic, double fovyRadians, double aspect, double focalDistance,
+                                       double near, double far) -> mathgl::Matrix4<double> {
+  // TODO(isaac@unfolded.ai): support orthographic
+  return orthographic ? throw new std::logic_error("orthographic not supported")
+                      : Matrix4<double>::makePerspective(fovyRadians, aspect, near, far);
 }
 
 void Viewport::_initViewMatrix(const ViewMatrixOptions& viewMatrixOptions) {
@@ -152,28 +144,89 @@ void Viewport::_initViewMatrix(const ViewMatrixOptions& viewMatrixOptions) {
   }
 
   this->viewMatrixUncentered = viewMatrixOptions.viewMatrix;
+
   // Make a centered version of the matrix for projection modes without an offset
-  // TODO(isaac@unfolded.ai): NEEDED
-  // this->viewMatrix = Matrix4<double>()
-  //                        // Apply the uncentered view matrix
-  //                        .multiplyRight(this->viewMatrixUncentered)
-  //                        // And center it
-  //                        .translate(this->center)
-  //                        .negate();
+  this->viewMatrix = (Matrix4<double>::MakeUnit() * this->viewMatrixUncentered).translate(-this->center);
+}
+
+auto Viewport::_getCenterInWorld(const mathgl::Vector2<double>& lngLat) -> mathgl::Vector3<double> {
+  // Make a centered version of the matrix for projection modes without an offset
+  auto center2d = this->projectFlat(lngLat);
+  auto center = Vector3<double>(center2d, 0);
+
+  // elided
+  // if (meterOffset) {
+  //   const commonPosition = new Vector3(meterOffset)
+  //     // Convert to pixels in current zoom
+  //     .scale(distanceScales.unitsPerMeter);
+  //   center.add(commonPosition);
+  // }
+
+  return center;
 }
 
 void Viewport::_initProjectionMatrix(const ProjectionMatrixOptions& opts) {
   this->projectionMatrix = opts.projectionMatrix.has_value()
                                ? opts.projectionMatrix.value()
-                               : this->_createProjectionMatrix(opts.orthographic, opts.fovyRadians, opts.aspect,
+                               : this->_createProjectionMatrix(opts.orthographic, opts.fovy, opts.aspect,
                                                                opts.focalDistance, opts.near, opts.far);
 }
 
-auto Viewport::_createProjectionMatrix(bool orthographic, double fovyRadians, double aspect, double focalDistance,
-                                       double near, double far) -> mathgl::Matrix4<double> {
-  // TODO(isaac@unfolded.ai): support orthographic
-  return orthographic ? throw new std::logic_error("orthographic not supported")
-                      : Matrix4<double>::makePerspective(fovyRadians, aspect, near, far);
+void Viewport::_initPixelMatrices() {
+  // Note: As usual, matrix operations should be applied in "reverse" order
+  // since vectors will be multiplied in from the right during transformation
+  auto vpm = Matrix4<double>::MakeUnit();
+  vpm = vpm * this->projectionMatrix;
+  vpm = vpm * this->viewMatrix;
+
+  // Flip the view projection matrix on Z-axis in order to make it WebGPU-compatible
+  //  vpm = vpm * Matrix4<double>{1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0};
+
+  this->viewProjectionMatrix = vpm;
+
+  /*
+  // Calculate inverse view matrix
+  this.viewMatrixInverse = mat4.invert([], this.viewMatrix) || this.viewMatrix;
+
+  // Decompose camera directions
+  const {eye, direction, up, right} = extractCameraVectors({
+    viewMatrix: this.viewMatrix,
+    viewMatrixInverse: this.viewMatrixInverse
+  });
+  this.cameraPosition = eye;
+  this.cameraDirection = direction;
+  this.cameraUp = up;
+  this.cameraRight = right;
+
+  // console.log(this.cameraPosition, this.cameraDirection, this.cameraUp);
+  */
+
+  /*
+   * Builds matrices that converts preprojected lngLats to screen pixels
+   * and vice versa.
+   * Note: Currently returns bottom-left coordinates!
+   * Note: Starts with the GL projection matrix and adds steps to the
+   *       scale and translate that matrix onto the window.
+   * Note: WebGL controls clip space to screen projection with gl.viewport
+   *       and does not need this step.
+   */
+
+  /*
+  // matrix for conversion from world location to screen (pixel) coordinates
+  const viewportMatrix = createMat4(); // matrix from NDC to viewport.
+  const pixelProjectionMatrix = createMat4(); // matrix from world space to viewport.
+  mat4.scale(viewportMatrix, viewportMatrix, [this.width / 2, -this.height / 2, 1]);
+  mat4.translate(viewportMatrix, viewportMatrix, [1, -1, 0]);
+  mat4.multiply(pixelProjectionMatrix, viewportMatrix, this.viewProjectionMatrix);
+  this.pixelProjectionMatrix = pixelProjectionMatrix;
+  this.viewportMatrix = viewportMatrix;
+
+  this.pixelUnprojectionMatrix = mat4.invert(createMat4(), this.pixelProjectionMatrix);
+  if (!this.pixelUnprojectionMatrix) {
+    log.warn('Pixel project matrix not invertible')();
+    // throw new Error('Pixel project matrix not invertible');
+  }
+  */
 }
 
 auto operator==(const Viewport& v1, const Viewport& v2) -> bool {

--- a/cpp/modules/deck.gl/core/test/shaderlib/project/viewport-uniforms-test.cpp
+++ b/cpp/modules/deck.gl/core/test/shaderlib/project/viewport-uniforms-test.cpp
@@ -27,9 +27,76 @@
 using namespace mathgl;
 using namespace deckgl;
 
-TEST(ViewportUniforms, Simple) {
+/// \brief Fixture for testing viewport-uniforms implementation.
+class ViewportUniformsTest : public ::testing::Test {
+ protected:
+  ViewportUniformsTest() {}
+};
+
+TEST_F(ViewportUniformsTest, Simple) {
   // TODO(isaac@unfolded.ai): Add tests
 
   // TODO(isaac@unfolded.ai): Check for non-finite outputs
   // TODO(isaac@unfolded.ai): Check for coordinate origin (copy from JS)
+}
+
+// Ensures viewport uniform values are correct by comparing them to a known expected output.
+// Input and output values taken from web-based deck.gl Flight Paths example.
+TEST_F(ViewportUniformsTest, WebMercator) {
+  WebMercatorViewport::Options opts;
+  opts.width = 640;
+  opts.height = 480;
+  opts.longitude = 7.0;
+  opts.latitude = 47.65;
+  opts.zoom = 4.5;
+  opts.pitch = 50.0;
+  opts.bearing = 0.0;
+
+  auto viewport = std::make_shared<WebMercatorViewport>(opts);
+  auto uniforms = getUniformsFromViewport(viewport, 1, Matrix4<double>::MakeUnit(), COORDINATE_SYSTEM::DEFAULT,
+                                          Vector3<double>{}, false);
+
+  auto viewProjectionMatrix = Matrix4<double>{0.1060660171779,
+                                              0.0,
+                                              0.0,
+                                              -28.20884652413,
+                                              0.0,
+                                              0.0909038955344,
+                                              0.1083350440839,
+                                              -30.29645116876,
+                                              0.0,
+                                              0.03910417422475,
+                                              -0.0328122981694,
+                                              -11.61662474340,
+                                              0.0,
+                                              0.0361116813613,
+                                              -0.03030129851146,
+                                              -10.53530150774};
+  auto viewportSize = Vector2<float>{640.0, 480.0};
+
+  EXPECT_EQ(uniforms.coordinateSystem, 1);
+  EXPECT_EQ(uniforms.projectionMode, 1);
+  EXPECT_FLOAT_EQ(uniforms.scale, 22.62741699796952f);
+  //  EXPECT_EQ(uniforms.wrapLongitude, false);
+  EXPECT_FLOAT_EQ(uniforms.antimeridian, -173.0f);
+  EXPECT_EQ(uniforms.center, Vector4<float>{});
+  EXPECT_EQ(uniforms.modelMatrix, Matrix4<float>::MakeUnit());
+  EXPECT_EQ(uniforms.viewProjectionMatrix, Matrix4<float>{viewProjectionMatrix});
+  EXPECT_EQ(uniforms.viewportSize, viewportSize);
+  EXPECT_FLOAT_EQ(uniforms.devicePixelRatio, 1.0);
+  EXPECT_FLOAT_EQ(uniforms.focalDistance, 1.0);
+  EXPECT_EQ(uniforms.coordinateOrigin, Vector3<float>{});
+
+  // Currently not calculated
+  //  auto cameraPosition = Vector3<float>{265.9555555555556, 308.9046245972715, 20.45337649524195};
+  //  EXPECT_EQ(uniforms.cameraPosition, cameraPosition);
+
+  // Many small numbers that are hard to match consistently, should be tested as part of math.gl web-mercator-utils
+  //  auto commonUnitsPerMeter = Vector3<float>{1.89e-05, 1.89e-05, 1.89e-05};
+  //  auto commonUnitsPerWorldUnit = Vector3<float>{1.422222222222, 2.12548, 1.91e-05};
+  //  auto commonUnitsPerWorldUnit2 = Vector3<float>{0.0, 0.0206, 3.70e-07};
+  //
+  //  EXPECT_EQ(uniforms.commonUnitsPerMeter, commonUnitsPerMeter);
+  //  EXPECT_EQ(uniforms.commonUnitsPerWorldUnit, commonUnitsPerWorldUnit);
+  //  EXPECT_EQ(uniforms.commonUnitsPerWorldUnit2, commonUnitsPerWorldUnit2);
 }

--- a/cpp/modules/deck.gl/core/test/viewports/viewport-test.cpp
+++ b/cpp/modules/deck.gl/core/test/viewports/viewport-test.cpp
@@ -27,10 +27,16 @@
 using namespace mathgl;
 using namespace deckgl;
 
-TEST(Viewport, Simple) {
+/// \brief Fixture for testing Viewport implementation.
+class ViewportTest : public ::testing::Test {
+ protected:
+  ViewportTest() {}
+};
+
+TEST_F(ViewportTest, Simple) {
   ViewMatrixOptions viewMatrixOptions;
   ProjectionMatrixOptions projectionMatrixOptions;
-  Viewport viewport("my-viewport-id", viewMatrixOptions, projectionMatrixOptions, 0, 0, 0, 0);
+  Viewport viewport{"my-viewport-id", viewMatrixOptions, projectionMatrixOptions, 0, 0, 0, 0};
   EXPECT_FALSE(viewport.containsPixel(0, 0));
   viewport.width = 10;
   viewport.height = 10;

--- a/cpp/modules/deck.gl/core/test/viewports/web-mercator-viewport-test.cpp
+++ b/cpp/modules/deck.gl/core/test/viewports/web-mercator-viewport-test.cpp
@@ -32,8 +32,8 @@ auto const LNGLAT_TOLERANCE = 1e-6;
 auto const OFFSET_TOLERANCE = 1e-5;
 auto const ZOOM_TOLERANCE = 1e-6;
 
-WebMercatorViewport makeTestViewport(int width, int height, double longitude, double latitude, double zoom,
-                                     double pitch, double bearing) {
+auto makeTestViewport(int width, int height, double longitude, double latitude, double zoom, double pitch,
+                      double bearing) -> WebMercatorViewport {
   WebMercatorViewport::Options opts;
   opts.width = width;
   opts.height = height;
@@ -43,19 +43,35 @@ WebMercatorViewport makeTestViewport(int width, int height, double longitude, do
   opts.pitch = pitch;
   opts.bearing = bearing;
 
-  return WebMercatorViewport(opts);
+  return WebMercatorViewport{opts};
 }
 
 const WebMercatorViewport TEST_VIEWPORTS[] = {makeTestViewport(800, 600, -122, 38, 11, 0, 0),
                                               makeTestViewport(800, 600, 20, 23, 15, 30, -85),
                                               makeTestViewport(800, 600, 42, 65, 16, 15, 30)};
 
-TEST(WebMercatorViewport, Ctor) {
+/// \brief Fixture for testing WebMercatorViewport implementation.
+class WebMercatorViewportTest : public ::testing::Test {
+ protected:
+  WebMercatorViewportTest() {}
+};
+
+TEST_F(WebMercatorViewportTest, Simple) {
+  ViewMatrixOptions viewMatrixOptions;
+  ProjectionMatrixOptions projectionMatrixOptions;
+  Viewport viewport{"my-viewport-id", viewMatrixOptions, projectionMatrixOptions, 0, 0, 0, 0};
+  EXPECT_FALSE(viewport.containsPixel(0, 0));
+  viewport.width = 10;
+  viewport.height = 10;
+  EXPECT_TRUE(viewport.containsPixel(2, 1, 5, 5));
+}
+
+TEST_F(WebMercatorViewportTest, Ctor) {
   // Construct with 0 width and height
   makeTestViewport(0, 0, 0, 0, 11, 0, 0);
 }
 
-TEST(WebMercatorViewport, projectFlat) {
+TEST_F(WebMercatorViewportTest, projectFlat) {
   for (auto viewport : TEST_VIEWPORTS) {
     for (auto tc : TEST_VIEWPORTS) {
       auto lngLatIn = Vector2<double>(tc.longitude, tc.latitude);
@@ -69,7 +85,7 @@ TEST(WebMercatorViewport, projectFlat) {
 }
 
 // TODO(isaac@unfolded.ai): project/unproject not implemented
-// TEST(WebMercatorViewport, project3D) {
+// TEST_F(WebMercatorViewportTest, project3D) {
 //   for (auto viewport : TEST_VIEWPORTS) {
 //     const double TEST_OFFSETS[] = {0, 0.5, 1.0, 5.0};
 //     for (auto offset : TEST_OFFSETS) {
@@ -87,7 +103,7 @@ TEST(WebMercatorViewport, projectFlat) {
 // }
 
 // TODO(isaac@unfolded.ai): project/unproject not implemented
-// TEST(WebMercatorViewport, project2D) {
+// TEST_F(WebMercatorViewportTest, project2D) {
 //   for (auto viewport : TEST_VIEWPORTS) {
 //     const double TEST_OFFSETS[] = {0, 0.5, 1.0, 5.0};
 //     for (auto offset : TEST_OFFSETS) {
@@ -103,7 +119,7 @@ TEST(WebMercatorViewport, projectFlat) {
 //   }
 // }
 
-TEST(WebMercatorViewport, getScales) {
+TEST_F(WebMercatorViewportTest, getScales) {
   for (auto viewport : TEST_VIEWPORTS) {
     auto distanceScales = viewport.getDistanceScales();
 
@@ -128,7 +144,7 @@ TEST(WebMercatorViewport, getScales) {
   }
 }
 
-TEST(WebMercatorViewport, fitBounds) {
+TEST_F(WebMercatorViewportTest, fitBounds) {
   struct fitBoundsArgs {
     Vector2<double> topLeft;
     Vector2<double> bottomRight;
@@ -169,4 +185,51 @@ TEST(WebMercatorViewport, fitBounds) {
     EXPECT_NEAR(result.zoom, EXPECTED[i].zoom, ZOOM_TOLERANCE);
     i++;
   }
+}
+
+// Ensures viewport matrix values are correct by comparing them to a known expected output.
+// Input and output values taken from web-based deck.gl Flight Paths example.
+TEST_F(WebMercatorViewportTest, FlightPathsMatrices) {
+  auto viewport = makeTestViewport(640, 480, 7.0, 47.65, 4.5, 50.0, 0.0);
+
+  auto projectionMatrix = Matrix4<double>{
+      2.25, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 0.0, -1.082867724532, -0.2082867724532, 0.0, 0.0, -1.0, 0.0};
+
+  auto viewMatrix = Matrix4<double>{0.0471404520791,
+                                    0.0,
+                                    0.0,
+                                    -12.53726512183,
+                                    0.0,
+                                    0.03030129851146,
+                                    0.0361116813613,
+                                    -10.09881705625,
+                                    0.0,
+                                    -0.0361116813613,
+                                    0.03030129851146,
+                                    10.53530150774,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0};
+
+  auto viewProjectionMatrix = Matrix4<double>{0.1060660171779,
+                                              0.0,
+                                              0.0,
+                                              -28.20884652413,
+                                              0.0,
+                                              0.0909038955344,
+                                              0.1083350440839,
+                                              -30.29645116876,
+                                              0.0,
+                                              0.03910417422475,
+                                              -0.0328122981694,
+                                              -11.61662474340,
+                                              0.0,
+                                              0.0361116813613,
+                                              -0.03030129851146,
+                                              -10.53530150774};
+
+  EXPECT_EQ(viewport.projectionMatrix, projectionMatrix);
+  EXPECT_EQ(viewport.viewMatrix, viewMatrix);
+  EXPECT_EQ(viewport.viewProjectionMatrix, viewProjectionMatrix);
 }

--- a/cpp/modules/deck.gl/json/src/json-object/json-object.cpp
+++ b/cpp/modules/deck.gl/json/src/json-object/json-object.cpp
@@ -31,7 +31,6 @@ using namespace deckgl;
 auto Property::_getPropFromJson(JSONObject* props, const Json::Value& jsonValue,
                                 const JSONConverter* jsonConverter) const -> std::shared_ptr<JSONObject> {
   auto typeHint = this->typeName;
-  std::cout << "getting prop" << typeHint << std::endl;
   std::shared_ptr<JSONObject> propsObject = {jsonConverter->convertClass(jsonValue, typeHint)};
   return propsObject;
 }

--- a/cpp/modules/deck.gl/json/src/json-object/json-object.h
+++ b/cpp/modules/deck.gl/json/src/json-object/json-object.h
@@ -318,16 +318,12 @@ inline bool JSONObject::hasProperty(const std::string& key) const { return this-
 
 template <class T>
 void JSONObject::setProperty(const std::string& key, const T& value) {
-  std::cout << "setProperty: getProperties" << std::endl;
   auto properties = this->getProperties();
   if (!properties) {
     throw std::logic_error("Props: No prop types found");
   }
-  std::cout << "setProperty: getProperty" << std::endl;
   if (auto propType = this->getProperties()->getProperty(key)) {
-    std::cout << "setProperty: dynamic_cast" << std::endl;
     if (auto propTypeT = dynamic_cast<const PropertyT<T>*>(propType)) {
-      std::cout << "setting prop" << std::endl;
       propTypeT->set(this, value);
     }
   }

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer-vertex.glsl.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer-vertex.glsl.h
@@ -44,6 +44,23 @@ vec3 instanceTargetPositions64Low = vec3(0.0);
 layout(location = 0) out vec4 vColor;
 layout(location = 1) out vec2 uv;
 
+// TODO(ilija@unfolded.ai): Debug code, remove
+layout(location = 2) out mat4 uModelMatrix;
+layout(location = 6) out mat4 uViewProjectionMatrix;
+layout(location = 10) out vec4 uCenter;
+layout(location = 11) out vec3 uCommonUnitsPerMeter;
+layout(location = 12) out vec3 uCommonUnitsPerWorldUnit;
+layout(location = 13) out vec3 uCommonUnitsPerWorldUnit2;
+layout(location = 14) out vec3 uCameraPosition;
+layout(location = 15) out vec3 uCoordinateOrigin;
+layout(location = 16) out vec2 uViewportSize;
+layout(location = 17) out int uCoordinateSystem;
+layout(location = 18) out int uProjectionMode;
+layout(location = 19) out float uScale;
+layout(location = 20) out float uAntimeridian;
+layout(location = 21) out float uDevicePixelRatio;
+layout(location = 22) out float uFocalDistance;
+
 // offset vector by strokeWidth pixels
 // offset_direction is -1 (left) or 1 (right)
 vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction, float width) {
@@ -56,6 +73,22 @@ vec2 getExtrusionOffset(vec2 line_clipspace, float offset_direction, float width
 }
 
 void main(void) {
+  uCoordinateSystem = project.uCoordinateSystem;
+  uProjectionMode = project.uProjectionMode;
+  uScale = project.uScale;
+  uAntimeridian = project.uAntimeridian;
+  uCommonUnitsPerMeter = project.uCommonUnitsPerMeter;
+  uCommonUnitsPerWorldUnit = project.uCommonUnitsPerWorldUnit;
+  uCommonUnitsPerWorldUnit2 = project.uCommonUnitsPerWorldUnit2;
+  uCenter = project.uCenter;
+  uModelMatrix = project.uModelMatrix;
+  uViewProjectionMatrix = project.uViewProjectionMatrix;
+  uViewportSize = project.uViewportSize;
+  uDevicePixelRatio = project.uDevicePixelRatio;
+  uFocalDistance = project.uFocalDistance;
+  uCameraPosition = project.uCameraPosition;
+  uCoordinateOrigin = project.uCoordinateOrigin;
+
   // Position
   vec4 sourceCommonspace;
   vec4 targetCommonspace;

--- a/cpp/modules/deck.gl/layers/src/line-layer/project-vertex.glsl.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/project-vertex.glsl.h
@@ -39,23 +39,25 @@ const int PROJECTION_MODE_WEB_MERCATOR = 1;
 const int PROJECTION_MODE_WEB_MERCATOR_AUTO_OFFSET = 4;
 const int PROJECTION_MODE_IDENTITY = 0;
 
+// Input matrices currently use row-major format, these will still be used as column-major within GLSL
+// https://www.khronos.org/opengl/wiki/Interface_Block_(GLSL)#Matrix_storage_order
 layout(std140, set = 0, binding = 0) uniform ProjectOptions {
-  int uCoordinateSystem;
-  int uProjectionMode;
-  float uScale;
-  bool uWrapLongitude;
-  float uAntimeridian;
-  vec3 uCommonUnitsPerMeter;
-  vec3 uCommonUnitsPerWorldUnit;
-  vec3 uCommonUnitsPerWorldUnit2;
-  vec4 uCenter;
   mat4 uModelMatrix;
   mat4 uViewProjectionMatrix;
-  vec2 uViewportSize;
-  float uDevicePixelRatio;
-  float uFocalDistance;
+  vec4 uCenter;
+  vec3 uCommonUnitsPerMeter;
+  int uCoordinateSystem;
+  vec3 uCommonUnitsPerWorldUnit;
+  int uProjectionMode;
+  vec3 uCommonUnitsPerWorldUnit2;
+  float uScale;
   vec3 uCameraPosition;
+  float uAntimeridian;
   vec3 uCoordinateOrigin;
+  float uDevicePixelRatio;
+  vec2 uViewportSize;
+  float uFocalDistance;
+  bool uWrapLongitude;
 } project;
 
 const float TILE_SIZE = 512.0;

--- a/cpp/modules/math.gl/core/src/core.h
+++ b/cpp/modules/math.gl/core/src/core.h
@@ -114,7 +114,7 @@ auto operator-(const Vector2<coord> &v1, const Vector2<coord> &v2) -> Vector2<co
 
 template <typename coord>
 auto operator==(const Vector2<coord> &v1, const Vector2<coord> &v2) -> bool {
-  return v1.x == v2.x && v1.y == v2.y;
+  return equalsT(v1.x, v2.x) && equalsT(v1.y, v2.y);
 }
 
 template <typename coord>
@@ -179,7 +179,7 @@ auto operator-(const Vector3<coord> &v1, const Vector3<coord> &v2) -> Vector3<co
 
 template <typename coord>
 auto operator==(const Vector3<coord> &v1, const Vector3<coord> &v2) -> bool {
-  return v1.x == v2.x && v1.y == v2.y && v1.z == v2.z;
+  return equalsT(v1.x, v2.x) && equalsT(v1.y, v2.y) && equalsT(v1.z, v2.z);
 }
 
 template <typename coord>
@@ -226,7 +226,11 @@ class Vector4 {
     return Vector4<coord>(x - v.x, y - v.y, z - v.z, w - v.w);
   }
 
-  auto operator==(const Vector4<coord> &v) const -> bool { return x == v.x && y == v.y && z == v.z && w == v.w; }
+  auto operator==(const Vector4<coord> &v) const -> bool {
+    return equalsT(x, v.x) && equalsT(y, v.y) && equalsT(z, v.z) && equalsT(w, v.w);
+  }
+
+  auto transform(const Matrix4<coord> &m) const -> Vector4<coord>;
 
   // TODO(ilija@unfolded.ai): These are not implemented?
   coord Length() const;
@@ -393,7 +397,9 @@ class Matrix4 {
   auto MultiplyPoint(const Vector3<coord> &) const -> Vector3<coord>;
 
   auto scale(const Vector3<coord> &) const -> Matrix4<coord>;
-  auto transform(const Vector4<coord> &) const -> Vector4<coord>;
+  auto translate(const Vector3<coord> &t) const -> Matrix4<coord>;
+  auto rotateX(const coord rad) -> Matrix4<coord>;
+  auto rotateY(const coord rad) -> Matrix4<coord>;
 
   coord m[4][4];
 };
@@ -415,11 +421,13 @@ auto operator<<(std::ostream &os, const Matrix4<coord> &m) -> std::ostream & {
 }
 
 template <typename coord>
-auto operator==(const Matrix4<coord> &m1, const Matrix4<coord> &m2) -> bool {
-  return m1.m[0][0] == m2.m[0][0] && m1.m[0][1] == m2.m[0][1] && m1.m[0][2] == m2.m[0][2] && m1.m[0][3] == m2.m[0][3] &&
-         m1.m[1][0] == m2.m[1][0] && m1.m[1][1] == m2.m[1][1] && m1.m[1][2] == m2.m[1][2] && m1.m[1][3] == m2.m[1][3] &&
-         m1.m[2][0] == m2.m[2][0] && m1.m[2][1] == m2.m[2][1] && m1.m[2][2] == m2.m[2][2] && m1.m[2][3] == m2.m[2][3] &&
-         m1.m[3][0] == m2.m[3][0] && m1.m[3][1] == m2.m[3][1] && m1.m[3][2] == m2.m[3][2] && m1.m[3][3] == m2.m[3][3];
+auto operator==(const Matrix4<coord> &l, const Matrix4<coord> &r) -> bool {
+  return equalsT(l(0, 0), r(0, 0)) && equalsT(l(0, 1), r(0, 1)) && equalsT(l(0, 2), r(0, 2)) &&
+         equalsT(l(0, 3), r(0, 3)) && equalsT(l(1, 0), r(1, 0)) && equalsT(l(1, 1), r(1, 1)) &&
+         equalsT(l(1, 2), r(1, 2)) && equalsT(l(1, 3), r(1, 3)) && equalsT(l(2, 0), r(2, 0)) &&
+         equalsT(l(2, 1), r(2, 1)) && equalsT(l(2, 2), r(2, 2)) && equalsT(l(2, 3), r(2, 3)) &&
+         equalsT(l(3, 0), r(3, 0)) && equalsT(l(3, 1), r(3, 1)) && equalsT(l(3, 2), r(3, 2)) &&
+         equalsT(l(3, 3), r(3, 3));
 }
 
 template <typename coord>
@@ -571,6 +579,17 @@ template <typename coord>
 auto operator<<(std::ostream &os, const Vector3<coord> &v) -> std::ostream & {
   os << "(" << v.x << "," << v.y << "," << v.z << ")";
   return os;
+}
+
+////////////////////////////
+// Vector4 implementation //
+////////////////////////////
+
+template <typename coord>
+auto Vector4<coord>::transform(const Matrix4<coord> &m) const -> Vector4<coord> {
+  return Vector4<coord>{
+      m(0, 0) * x + m(0, 1) * y + m(0, 2) * z + m(0, 3) * w, m(1, 0) * x + m(1, 1) * y + m(1, 2) * z + m(1, 3) * w,
+      m(2, 0) * x + m(2, 1) * y + m(2, 2) * z + m(2, 3) * w, m(3, 0) * x + m(3, 1) * y + m(3, 2) * z + m(3, 3) * w};
 }
 
 ///////////////////////////////////////////////////////////
@@ -859,8 +878,21 @@ template <typename coord>
 auto Matrix4<coord>::makePerspective(coord fovy, coord aspect, coord near, coord far) -> Matrix4<coord> {
   auto f = 1.0 / tan(fovy / 2.0);
   auto nf = 1.0 / (near - far);
+
+  auto zero = static_cast<coord>(0);
+  auto m22 = (far + near) * nf;
+  auto m23 = 2.0 * far * near * nf;
+
   // TODO(ib@unfolded.ai): Doesn't support far not being set or far being Infinity
-  return Matrix4<coord>(f / aspect, 0, 0, 0, 0, f, 0, 0, 0, 0, (far + near) * nf, -1, 0, 0, 2.0 * far * near * nf, 0);
+  return Matrix4<coord>{
+      f / aspect, zero, zero, zero, zero, f, zero, zero, zero, zero, m22, m23, zero, zero, static_cast<coord>(-1),
+      zero};
+}
+
+template <typename coord>
+auto Matrix4<coord>::Transpose() const -> Matrix4<coord> {
+  return Matrix4<coord>{m[0][0], m[1][0], m[2][0], m[3][0], m[0][1], m[1][1], m[2][1], m[3][1],
+                        m[0][2], m[1][2], m[2][2], m[3][2], m[0][3], m[1][3], m[2][3], m[3][3]};
 }
 
 template <typename coord>
@@ -888,17 +920,85 @@ auto Matrix4<coord>::MultiplyPoint(const Vector3<coord> &s) const -> Vector3<coo
 
 template <typename coord>
 auto Matrix4<coord>::scale(const Vector3<coord> &s) const -> Matrix4<coord> {
-  return Matrix4<coord>(m[0][0] * s.x, m[0][1] * s.x, m[0][2] * s.x, m[0][3] * s.x, m[1][0] * s.y, m[1][1] * s.y,
-                        m[1][2] * s.y, m[1][3] * s.y, m[2][0] * s.z, m[2][1] * s.z, m[2][2] * s.z, m[2][3] * s.z,
-                        m[3][0], m[3][1], m[3][2], m[3][3]);
+  auto scaleMatrix = Matrix4<coord>::MakeScale(s);
+  return *this * scaleMatrix;
+
+  /*
+  return Matrix4<coord>{m[0][0] * s.x, m[0][1] * s.y, m[0][2] * s.z, m[0][3],
+                        m[1][0] * s.x, m[1][1] * s.y, m[1][2] * s.z, m[1][3],
+                        m[2][0] * s.x, m[2][1] * s.y, m[2][2] * s.z, m[2][3],
+                        m[3][0] * s.x, m[3][1] * s.y, m[3][2] * s.z, m[3][3]};
+  */
 }
 
 template <typename coord>
-auto Matrix4<coord>::transform(const Vector4<coord> &xyzw) const -> Vector4<coord> {
-  return Vector4<coord>(m[0][0] * xyzw.x + m[1][0] * xyzw.y + m[2][0] * xyzw.z + m[3][0] * xyzw.w,
-                        m[0][1] * xyzw.x + m[1][1] * xyzw.y + m[2][1] * xyzw.z + m[3][1] * xyzw.w,
-                        m[0][2] * xyzw.x + m[1][2] * xyzw.y + m[2][2] * xyzw.z + m[3][2] * xyzw.w,
-                        m[0][3] * xyzw.x + m[1][3] * xyzw.y + m[2][3] * xyzw.z + m[3][3] * xyzw.w);
+auto Matrix4<coord>::translate(const Vector3<coord> &t) const -> Matrix4<coord> {
+  auto translationMatrix = Matrix4<coord>::MakeTranslation(t);
+  return *this * translationMatrix;
+
+  /*
+  auto m03 = m[0][0] * t.x + m[0][1] * t.y + m[0][2] * t.z + m[0][3];
+  auto m13 = m[1][0] * t.x + m[1][1] * t.y + m[1][2] * t.z + m[1][3];
+  auto m23 = m[2][0] * t.x + m[2][1] * t.y + m[2][2] * t.z + m[2][3];
+  auto m33 = m[3][0] * t.x + m[3][1] * t.y + m[3][2] * t.z + m[3][3];
+
+  return Matrix4<coord>{m[0][0], m[0][1], m[0][2], m03,
+                        m[1][0], m[1][1], m[1][2], m13,
+                        m[2][0], m[2][1], m[2][2], m23,
+                        m[3][0], m[3][1], m[3][2], m33};
+  */
+}
+
+template <typename coord>
+auto Matrix4<coord>::rotateX(const coord rad) -> Matrix4<coord> {
+  auto rotationVector = Matrix4<coord>::MakeRotationX(rad);
+  return *this * rotationVector;
+
+  /*
+  auto s = sin(rad);
+  auto c = cos(rad);
+
+  auto m01 = m[0][1] * c + m[0][2] * s;
+  auto m11 = m[1][1] * c + m[1][2] * s;
+  auto m21 = m[2][1] * c + m[2][2] * s;
+  auto m31 = m[3][1] * c + m[3][2] * s;
+
+  auto m02 = m[0][2] * c - m[0][1] * s;
+  auto m12 = m[1][2] * c - m[1][1] * s;
+  auto m22 = m[2][2] * c - m[2][1] * s;
+  auto m32 = m[3][2] * c - m[3][1] * s;
+
+  return Matrix4<coord>{m[0][0], m01, m02, m[0][3],
+                        m[1][0], m11, m12, m[1][3],
+                        m[2][0], m21, m22, m[2][3],
+                        m[3][0], m31, m32, m[3][3]};
+  */
+}
+
+template <typename coord>
+auto Matrix4<coord>::rotateY(const coord rad) -> Matrix4<coord> {
+  auto rotationVector = Matrix4<coord>::MakeRotationY(rad);
+  return *this * rotationVector;
+
+  /*
+  auto s = sin(rad);
+  auto c = cos(rad);
+
+  auto m00 = m[0][0] * c - m[0][2] * s;
+  auto m10 = m[1][0] * c - m[1][2] * s;
+  auto m20 = m[2][0] * c - m[2][2] * s;
+  auto m30 = m[3][0] * c - m[3][2] * s;
+
+  auto m02 = m[0][0] * s + m[0][2] * c;
+  auto m12 = m[1][0] * s + m[1][2] * c;
+  auto m22 = m[2][0] * s + m[2][2] * c;
+  auto m32 = m[3][0] * s + m[3][2] * c;
+
+  return Matrix4<coord>{m00, m[0][1], m02, m[0][3],
+                        m10, m[1][1], m12, m[1][3],
+                        m20, m[2][1], m22, m[2][3],
+                        m30, m[3][1], m32, m[3][3]};
+  */
 }
 
 template <typename coord>

--- a/cpp/modules/math.gl/web-mercator/src/web-mercator-utils.h
+++ b/cpp/modules/math.gl/web-mercator/src/web-mercator-utils.h
@@ -78,14 +78,15 @@ struct ProjectionMatrixOptions {
 
   // Projection matrix parameters, used if projectionMatrix not supplied
   bool orthographic{false};
-  double fovyRadians{0};
-  double fovy{75};
+  double fovy{0};
   double aspect{0};
   // Distance of near clipping plane
   double near{0.1};
   // Distance of far clipping plane
   double far{1000};
   double focalDistance{1};
+
+  auto fovyDegrees() -> double { return this->fovy * RADIANS_TO_DEGREES; }
 
   ProjectionMatrixOptions();
   ProjectionMatrixOptions(double fov, double aspect, double focalDistance, double near, double far);

--- a/deck.gl-native.xcodeproj/project.pbxproj
+++ b/deck.gl-native.xcodeproj/project.pbxproj
@@ -2434,10 +2434,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					"/Users/Ilija/Developer/Workspaces/C++/deck.gl-native/cpp/deps/x64-osx/include",
-					"/Users/Ilija/Developer/Workspaces/C++/deck.gl-native/cpp/modules",
+					"${PROJECT_DIR}/cpp/modules",
+					"${PROJECT_DIR}/cpp/deps/x64-osx/include",
 				);
-				LIBRARY_SEARCH_PATHS = "/Users/Ilija/Developer/Workspaces/C++/deck.gl-native/cpp/deps/x64-osx/lib";
+				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/cpp/deps/x64-osx/lib";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				ONLY_ACTIVE_ARCH = YES;
 			};
@@ -2479,10 +2479,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					"/Users/Ilija/Developer/Workspaces/C++/deck.gl-native/cpp/deps/x64-osx/include",
-					"/Users/Ilija/Developer/Workspaces/C++/deck.gl-native/cpp/modules",
+					"${PROJECT_DIR}/cpp/modules",
+					"${PROJECT_DIR}/cpp/deps/x64-osx/include",
 				);
-				LIBRARY_SEARCH_PATHS = "/Users/Ilija/Developer/Workspaces/C++/deck.gl-native/cpp/deps/x64-osx/lib";
+				LIBRARY_SEARCH_PATHS = "${PROJECT_DIR}/cpp/deps/x64-osx/lib";
 				MTL_ENABLE_DEBUG_INFO = NO;
 			};
 			name = Release;


### PR DESCRIPTION
Nothing draws yet, still seeing `nan`s for some of the output positions, and most of the triangles are degenerate (multiple equivalent points). All the shader input *should* be correct at this point, so it comes down to debugging shader code. Two things that would be useful in order to do that efficiently:
- Somehow get Xcode shader debugger to work. I am not sure whether it's possible as it is a Metal shader debugger
- Get some sample output out of web-based example in order to compare some of the values in order to get a clue about where things are going wrong. I currently have no idea what range some of these values are supposed to be in

In this PR:
- Added/fixed `viewMatrix`, `projectionMatrix` and `viewProjectionMatrix` calculations
- Fixed invalid math functions
- Added tests for `WebMercatorViewport` and `ViewportUniforms` based on expected values for flight paths example
- Fixed uniform memory alignment issues. I left the debug code in the shader that confirms uniforms are passed correctly and have appropriate values
- Currently only transposed the `viewProjectionMatrix` in order for it to match GLSL column-major format. Uniform layout should use `row_major` specifier, but I thought this may be more verbose for first iteration
- Absolute paths in Xcode project removed