### PR TITLE
Row getVector* methods are now templates

### DIFF
--- a/cpp/examples/deck.gl/flight-paths.cc
+++ b/cpp/examples/deck.gl/flight-paths.cc
@@ -47,18 +47,13 @@ auto createLineLayer(const std::string &dataPath) -> std::shared_ptr<LineLayer::
   lineLayerProps->id = "flight-paths";
   lineLayerProps->opacity = 0.8f;
   lineLayerProps->getSourcePosition = [](const Row &row) -> mathgl::Vector3<float> {
-    // NOTE: Decimal array data is being loaded as double
-    auto startPositions = row.getDoubleVector3("start");
-    return mathgl::Vector3<float>{startPositions};
+    return row.getVector3<float>("start");
   };
   lineLayerProps->getTargetPosition = [](const Row &row) -> mathgl::Vector3<float> {
-    // NOTE: Decimal array data is being loaded as double
-    auto endPositions = row.getDoubleVector3("end");
-    return mathgl::Vector3<float>{endPositions};
+    return row.getVector3<float>("end");
   };
   lineLayerProps->getColor = [](const Row &row) -> mathgl::Vector4<float> {
-    // NOTE: Decimal array data is being loaded as double
-    float z = static_cast<float>(row.getDoubleVector3("start").z);
+    float z = row.getVector3<float>("start").z;
     float r = z / 10000.0f;
     return {255.0f * (1.0f - r * 2.0f), 128.0f * r, 255.0f * r, 255.0f * (1.0f - r)};
   };

--- a/cpp/modules/deck.gl/core/src/arrow/row.cc
+++ b/cpp/modules/deck.gl/core/src/arrow/row.cc
@@ -41,7 +41,7 @@ auto Row::getInt(const std::string& columnName, int defaultValue) const -> int {
 
   auto chunk = this->_getChunk(columnName);
   auto doubleValue = this->_getDouble(chunk);
-  if (doubleValue.has_value()) {
+  if (doubleValue) {
     return static_cast<int>(doubleValue.value());
   }
 
@@ -55,7 +55,7 @@ auto Row::getFloat(const std::string& columnName, float defaultValue) const -> f
 
   auto chunk = this->_getChunk(columnName);
   auto doubleValue = this->_getDouble(chunk);
-  if (doubleValue.has_value()) {
+  if (doubleValue) {
     return static_cast<float>(doubleValue.value());
   }
 
@@ -69,7 +69,7 @@ auto Row::getDouble(const std::string& columnName, double defaultValue) const ->
 
   auto chunk = this->_getChunk(columnName);
   auto doubleValue = this->_getDouble(chunk);
-  if (doubleValue.has_value()) {
+  if (doubleValue) {
     return doubleValue.value();
   }
 
@@ -102,171 +102,6 @@ auto Row::getString(const std::string& columnName, const std::string& defaultVal
   }
 
   return defaultValue;
-}
-
-auto Row::getFloatVector2(const std::string& columnName, const Vector2<float>& defaultValue) const -> Vector2<float> {
-  if (!this->isValid(columnName)) {
-    return defaultValue;
-  }
-
-  auto chunk = this->_getChunk(columnName);
-  switch (chunk->type_id()) {
-    case arrow::Type::FIXED_SIZE_LIST: {
-      auto listArray = std::static_pointer_cast<arrow::FixedSizeListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::FloatArray>(listArray->values());
-      return this->_vector2FromFloatArray(values, offset, listArray->value_length(), defaultValue);
-    }
-    case arrow::Type::LIST: {
-      auto listArray = std::static_pointer_cast<arrow::ListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-      auto length = listArray->value_length(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::FloatArray>(listArray->values());
-      return this->_vector2FromFloatArray(values, offset, length, defaultValue);
-    }
-    default:
-      return defaultValue;
-  }
-}
-
-auto Row::getDoubleVector2(const std::string& columnName, const Vector2<double>& defaultValue) const
-    -> Vector2<double> {
-  if (!this->isValid(columnName)) {
-    return defaultValue;
-  }
-
-  auto chunk = this->_getChunk(columnName);
-  switch (chunk->type_id()) {
-    case arrow::Type::FIXED_SIZE_LIST: {
-      auto listArray = std::static_pointer_cast<arrow::FixedSizeListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::DoubleArray>(listArray->values());
-      return this->_vector2FromDoubleArray(values, offset, listArray->value_length(), defaultValue);
-    }
-    case arrow::Type::LIST: {
-      auto listArray = std::static_pointer_cast<arrow::ListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-      auto length = listArray->value_length(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::DoubleArray>(listArray->values());
-      return this->_vector2FromDoubleArray(values, offset, length, defaultValue);
-    }
-    default:
-      return defaultValue;
-  }
-}
-
-auto Row::getFloatVector3(const std::string& columnName, const Vector3<float>& defaultValue) const -> Vector3<float> {
-  if (!this->isValid(columnName)) {
-    return defaultValue;
-  }
-
-  auto chunk = this->_getChunk(columnName);
-  switch (chunk->type_id()) {
-    case arrow::Type::FIXED_SIZE_LIST: {
-      auto listArray = std::static_pointer_cast<arrow::FixedSizeListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::FloatArray>(listArray->values());
-      return this->_vector3FromFloatArray(values, offset, listArray->value_length(), defaultValue);
-    }
-    case arrow::Type::LIST: {
-      auto listArray = std::static_pointer_cast<arrow::ListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-      auto length = listArray->value_length(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::FloatArray>(listArray->values());
-      return this->_vector3FromFloatArray(values, offset, length, defaultValue);
-    }
-    default:
-      return defaultValue;
-  }
-}
-
-auto Row::getDoubleVector3(const std::string& columnName, const Vector3<double>& defaultValue) const
-    -> Vector3<double> {
-  if (!this->isValid(columnName)) {
-    return defaultValue;
-  }
-
-  auto chunk = this->_getChunk(columnName);
-  switch (chunk->type_id()) {
-    case arrow::Type::FIXED_SIZE_LIST: {
-      auto listArray = std::static_pointer_cast<arrow::FixedSizeListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::DoubleArray>(listArray->values());
-      return this->_vector3FromDoubleArray(values, offset, listArray->value_length(), defaultValue);
-    }
-    case arrow::Type::LIST: {
-      auto listArray = std::static_pointer_cast<arrow::ListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-      auto length = listArray->value_length(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::DoubleArray>(listArray->values());
-      return this->_vector3FromDoubleArray(values, offset, length, defaultValue);
-    }
-    default:
-      return defaultValue;
-  }
-}
-
-auto Row::getFloatVector4(const std::string& columnName, const Vector4<float>& defaultValue) const -> Vector4<float> {
-  if (!this->isValid(columnName)) {
-    return defaultValue;
-  }
-
-  auto chunk = this->_getChunk(columnName);
-  switch (chunk->type_id()) {
-    case arrow::Type::FIXED_SIZE_LIST: {
-      auto listArray = std::static_pointer_cast<arrow::FixedSizeListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::FloatArray>(listArray->values());
-      return this->_vector4FromFloatArray(values, offset, listArray->value_length(), defaultValue);
-    }
-    case arrow::Type::LIST: {
-      auto listArray = std::static_pointer_cast<arrow::ListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-      auto length = listArray->value_length(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::FloatArray>(listArray->values());
-      return this->_vector4FromFloatArray(values, offset, length, defaultValue);
-    }
-    default:
-      return defaultValue;
-  }
-}
-
-auto Row::getDoubleVector4(const std::string& columnName, const Vector4<double>& defaultValue) const
-    -> Vector4<double> {
-  if (!this->isValid(columnName)) {
-    return defaultValue;
-  }
-
-  auto chunk = this->_getChunk(columnName);
-  switch (chunk->type_id()) {
-    case arrow::Type::FIXED_SIZE_LIST: {
-      auto listArray = std::static_pointer_cast<arrow::FixedSizeListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::DoubleArray>(listArray->values());
-      return this->_vector4FromDoubleArray(values, offset, listArray->value_length(), defaultValue);
-    }
-    case arrow::Type::LIST: {
-      auto listArray = std::static_pointer_cast<arrow::ListArray>(chunk);
-      auto offset = listArray->value_offset(this->_chunkRowIndex);
-      auto length = listArray->value_length(this->_chunkRowIndex);
-
-      auto values = std::static_pointer_cast<arrow::DoubleArray>(listArray->values());
-      return this->_vector4FromDoubleArray(values, offset, length, defaultValue);
-    }
-    default:
-      return defaultValue;
-  }
 }
 
 auto Row::isValid(const std::string& columnName) const -> bool {
@@ -365,110 +200,24 @@ auto Row::_getDouble(const std::shared_ptr<arrow::Array>& chunk) const -> std::o
   }
 }
 
-auto Row::_vector2FromFloatArray(const std::shared_ptr<arrow::FloatArray>& values, int32_t offset, int32_t listSize,
-                                 const Vector2<float>& defaultValue) const -> Vector2<float> {
-  if (values->type_id() != arrow::Type::FLOAT) {
-    return defaultValue;
+auto Row::_getListArrayMetadata(const std::shared_ptr<arrow::Array>& array, int64_t index) const
+    -> std::shared_ptr<ListArrayMetadata> {
+  switch (array->type_id()) {
+    case arrow::Type::FIXED_SIZE_LIST: {
+      auto listArray = std::static_pointer_cast<arrow::FixedSizeListArray>(array);
+      auto offset = listArray->value_offset(index);
+      auto length = listArray->value_length();
+
+      return std::make_shared<ListArrayMetadata>(offset, length, listArray->values());
+    }
+    case arrow::Type::LIST: {
+      auto listArray = std::static_pointer_cast<arrow::ListArray>(array);
+      auto offset = listArray->value_offset(index);
+      auto length = listArray->value_length(index);
+
+      return std::make_shared<ListArrayMetadata>(offset, length, listArray->values());
+    }
+    default:
+      return nullptr;
   }
-  if (listSize < 1) {
-    return defaultValue;
-  }
-
-  // Buffer at index 0 contains null bitmap, the actual data is in the buffer at index 1 for majority of the data types
-  auto listPointer = values->data()->GetValues<float>(1);
-  const float first = *(listPointer + offset);
-  const float second = listSize >= 2 ? *(listPointer + offset + 1) : 0.0;
-
-  return Vector2<float>{first, second};
-}
-
-auto Row::_vector2FromDoubleArray(const std::shared_ptr<arrow::DoubleArray>& values, int32_t offset, int32_t listSize,
-                                  const Vector2<double>& defaultValue) const -> Vector2<double> {
-  if (values->type_id() != arrow::Type::DOUBLE) {
-    return defaultValue;
-  }
-  if (listSize < 1) {
-    return defaultValue;
-  }
-
-  // Buffer at index 0 contains null bitmap, the actual data is in the buffer at index 1 for majority of the data types
-  auto listPointer = values->data()->GetValues<double>(1);
-  const double first = *(listPointer + offset);
-  const double second = listSize >= 2 ? *(listPointer + offset + 1) : 0.0;
-
-  return Vector2<double>{first, second};
-}
-
-auto Row::_vector3FromFloatArray(const std::shared_ptr<arrow::FloatArray>& values, int32_t offset, int32_t listSize,
-                                 const Vector3<float>& defaultValue) const -> Vector3<float> {
-  if (values->type_id() != arrow::Type::FLOAT) {
-    return defaultValue;
-  }
-  if (listSize < 2) {
-    return defaultValue;
-  }
-
-  // Buffer at index 0 contains null bitmap, the actual data is in the buffer at index 1 for majority of the data types
-  auto listPointer = values->data()->GetValues<float>(1);
-  const float first = *(listPointer + offset);
-  const float second = *(listPointer + offset + 1);
-  const float third = listSize >= 3 ? *(listPointer + offset + 2) : 0.0;
-
-  return Vector3<float>{first, second, third};
-}
-
-auto Row::_vector3FromDoubleArray(const std::shared_ptr<arrow::DoubleArray>& values, int32_t offset, int32_t listSize,
-                                  const Vector3<double>& defaultValue) const -> Vector3<double> {
-  if (values->type_id() != arrow::Type::DOUBLE) {
-    return defaultValue;
-  }
-  if (listSize < 2) {
-    return defaultValue;
-  }
-
-  // Buffer at index 0 contains null bitmap, the actual data is in the buffer at index 1 for majority of the data types
-  auto listPointer = values->data()->GetValues<double>(1);
-  const double first = *(listPointer + offset);
-  const double second = *(listPointer + offset + 1);
-  const double third = listSize >= 3 ? *(listPointer + offset + 2) : 0.0;
-
-  return Vector3<double>{first, second, third};
-}
-
-auto Row::_vector4FromFloatArray(const std::shared_ptr<arrow::FloatArray>& values, int32_t offset, int32_t listSize,
-                                 const Vector4<float>& defaultValue) const -> Vector4<float> {
-  if (values->type_id() != arrow::Type::FLOAT) {
-    return defaultValue;
-  }
-  if (listSize < 3) {
-    return defaultValue;
-  }
-
-  // Buffer at index 0 contains null bitmap, the actual data is in the buffer at index 1 for majority of the data types
-  auto listPointer = values->data()->GetValues<float>(1);
-  const float first = *(listPointer + offset);
-  const float second = *(listPointer + offset + 1);
-  const float third = *(listPointer + offset + 2);
-  const float fourth = listSize >= 4 ? *(listPointer + offset + 3) : 0.0;
-
-  return Vector4<float>{first, second, third, fourth};
-}
-
-auto Row::_vector4FromDoubleArray(const std::shared_ptr<arrow::DoubleArray>& values, int32_t offset, int32_t listSize,
-                                  const Vector4<double>& defaultValue) const -> Vector4<double> {
-  if (values->type_id() != arrow::Type::DOUBLE) {
-    return defaultValue;
-  }
-  if (listSize < 3) {
-    return defaultValue;
-  }
-
-  // Buffer at index 0 contains null bitmap, the actual data is in the buffer at index 1 for majority of the data types
-  auto listPointer = values->data()->GetValues<double>(1);
-  const double first = *(listPointer + offset);
-  const double second = *(listPointer + offset + 1);
-  const double third = *(listPointer + offset + 2);
-  const double fourth = listSize >= 4 ? *(listPointer + offset + 3) : 0.0;
-
-  return Vector4<double>{first, second, third, fourth};
 }

--- a/cpp/modules/deck.gl/core/src/arrow/row.h
+++ b/cpp/modules/deck.gl/core/src/arrow/row.h
@@ -28,10 +28,21 @@
 #include <optional>
 #include <string>
 #include <tuple>
+#include <vector>
 
 #include "math.gl/core.h"
 
 namespace deckgl {
+
+struct ListArrayMetadata {
+ public:
+  ListArrayMetadata(int32_t offset, int32_t length, const std::shared_ptr<arrow::Array>& values)
+      : offset{offset}, length{length}, values{values} {}
+
+  int32_t offset;
+  int32_t length;
+  std::shared_ptr<arrow::Array> values;
+};
 
 class Row {
  public:
@@ -43,18 +54,38 @@ class Row {
   auto getBool(const std::string& columnName, bool defaultValue = false) const -> bool;
   auto getString(const std::string& columnName, const std::string& defaultValue = "") const -> std::string;
 
-  auto getFloatVector2(const std::string& columnName, const mathgl::Vector2<float>& defaultValue = {}) const
-      -> mathgl::Vector2<float>;
-  auto getDoubleVector2(const std::string& columnName, const mathgl::Vector2<double>& defaultValue = {}) const
-      -> mathgl::Vector2<double>;
-  auto getFloatVector3(const std::string& columnName, const mathgl::Vector3<float>& defaultValue = {}) const
-      -> mathgl::Vector3<float>;
-  auto getDoubleVector3(const std::string& columnName, const mathgl::Vector3<double>& defaultValue = {}) const
-      -> mathgl::Vector3<double>;
-  auto getFloatVector4(const std::string& columnName, const mathgl::Vector4<float>& defaultValue = {}) const
-      -> mathgl::Vector4<float>;
-  auto getDoubleVector4(const std::string& columnName, const mathgl::Vector4<double>& defaultValue = {}) const
-      -> mathgl::Vector4<double>;
+  template <typename T>
+  auto getVector2(const std::string& columnName, const mathgl::Vector2<T>& defaultValue = {}) const
+      -> mathgl::Vector2<T> {
+    auto data = this->_getVectorData<T>(columnName);
+    if (!data) {
+      return defaultValue;
+    }
+
+    return mathgl::Vector2<T>{data->size() > 0 ? data->at(0) : 0, data->size() > 1 ? data->at(1) : 0};
+  }
+  template <typename T>
+  auto getVector3(const std::string& columnName, const mathgl::Vector3<T>& defaultValue = {}) const
+      -> mathgl::Vector3<T> {
+    auto data = this->_getVectorData<T>(columnName);
+    if (!data) {
+      return defaultValue;
+    }
+
+    return mathgl::Vector3<T>{data->size() > 0 ? data->at(0) : 0, data->size() > 1 ? data->at(1) : 0,
+                              data->size() > 2 ? data->at(2) : 0};
+  }
+  template <typename T>
+  auto getVector4(const std::string& columnName, const mathgl::Vector4<T>& defaultValue = {}) const
+      -> mathgl::Vector4<T> {
+    auto data = this->_getVectorData<T>(columnName);
+    if (!data) {
+      return defaultValue;
+    }
+
+    return mathgl::Vector4<T>{data->size() > 0 ? data->at(0) : 0, data->size() > 1 ? data->at(1) : 0,
+                              data->size() > 2 ? data->at(2) : 0, data->size() > 3 ? data->at(3) : 0};
+  }
 
   /// \brief Checks whether value at this row, for columnName is valid and not null.
   /// \param columnName Name of the column who's value to check.
@@ -79,18 +110,40 @@ class Row {
   auto _getRowChunkData(const std::shared_ptr<arrow::Table>& table, int64_t rowIndex) const -> std::tuple<int, int64_t>;
 
   auto _getDouble(const std::shared_ptr<arrow::Array>& chunk) const -> std::optional<double>;
-  auto _vector2FromFloatArray(const std::shared_ptr<arrow::FloatArray>& values, int32_t offset, int32_t listSize,
-                              const mathgl::Vector2<float>& defaultValue) const -> mathgl::Vector2<float>;
-  auto _vector2FromDoubleArray(const std::shared_ptr<arrow::DoubleArray>& values, int32_t offset, int32_t listSize,
-                               const mathgl::Vector2<double>& defaultValue) const -> mathgl::Vector2<double>;
-  auto _vector3FromFloatArray(const std::shared_ptr<arrow::FloatArray>& values, int32_t offset, int32_t listSize,
-                              const mathgl::Vector3<float>& defaultValue) const -> mathgl::Vector3<float>;
-  auto _vector3FromDoubleArray(const std::shared_ptr<arrow::DoubleArray>& values, int32_t offset, int32_t listSize,
-                               const mathgl::Vector3<double>& defaultValue) const -> mathgl::Vector3<double>;
-  auto _vector4FromFloatArray(const std::shared_ptr<arrow::FloatArray>& values, int32_t offset, int32_t listSize,
-                              const mathgl::Vector4<float>& defaultValue) const -> mathgl::Vector4<float>;
-  auto _vector4FromDoubleArray(const std::shared_ptr<arrow::DoubleArray>& values, int32_t offset, int32_t listSize,
-                               const mathgl::Vector4<double>& defaultValue) const -> mathgl::Vector4<double>;
+  auto _getListArrayMetadata(const std::shared_ptr<arrow::Array>& array, int64_t index) const
+      -> std::shared_ptr<ListArrayMetadata>;
+
+  template <typename T>
+  auto _getVectorData(const std::string& columnName) const -> std::shared_ptr<std::vector<T>> {
+    if (!this->isValid(columnName)) {
+      return nullptr;
+    }
+
+    auto metadata = this->_getListArrayMetadata(this->_getChunk(columnName), this->_chunkRowIndex);
+
+    auto data = std::make_shared<std::vector<T>>();
+    if (auto doubleArray = std::dynamic_pointer_cast<arrow::DoubleArray>(metadata->values)) {
+      for (int i = 0; i < metadata->length; i++) {
+        data->push_back(static_cast<T>(doubleArray->Value(metadata->offset + i)));
+      }
+    } else if (auto floatArray = std::dynamic_pointer_cast<arrow::FloatArray>(metadata->values)) {
+      for (int i = 0; i < metadata->length; i++) {
+        data->push_back(static_cast<T>(floatArray->Value(metadata->offset + i)));
+      }
+    } else if (auto intArray = std::dynamic_pointer_cast<arrow::Int64Array>(metadata->values)) {
+      for (int i = 0; i < metadata->length; i++) {
+        data->push_back(static_cast<T>(intArray->Value(metadata->offset + i)));
+      }
+    } else if (auto intArray = std::dynamic_pointer_cast<arrow::Int32Array>(metadata->values)) {
+      for (int i = 0; i < metadata->length; i++) {
+        data->push_back(static_cast<T>(intArray->Value(metadata->offset + i)));
+      }
+    } else {
+      return nullptr;
+    }
+
+    return data;
+  }
 
   /// \brief Table that this row belongs to.
   std::shared_ptr<arrow::Table> _table;

--- a/cpp/modules/deck.gl/core/test/arrow/row-test.cc
+++ b/cpp/modules/deck.gl/core/test/arrow/row-test.cc
@@ -152,21 +152,21 @@ TEST_F(RowTest, GetString) {
 TEST_F(RowTest, getFloatVector2) {
   auto row = std::make_unique<Row>(table, 0);
   auto expectedVector = mathgl::Vector2<float>{355.1, -26.1};
-  EXPECT_EQ(row->getFloatVector2("list"), expectedVector);
+  EXPECT_EQ(row->getVector2<float>("list"), expectedVector);
 
   row = std::make_unique<Row>(table, 1);
   expectedVector = mathgl::Vector2<float>{};
-  EXPECT_EQ(row->getFloatVector2("list"), expectedVector);
+  EXPECT_EQ(row->getVector2<float>("list"), expectedVector);
 }
 
 TEST_F(RowTest, getDoubleVector3) {
   auto row = std::make_unique<Row>(table, 0);
   auto expectedVector = mathgl::Vector3<double>{-256.2, 0.0, 1.23};
-  EXPECT_EQ(row->getDoubleVector3("fixed_list"), expectedVector);
+  EXPECT_EQ(row->getVector3<double>("fixed_list"), expectedVector);
 
   row = std::make_unique<Row>(table, 1);
   expectedVector = mathgl::Vector3<double>{1.0, 2.0, 3.0};
-  EXPECT_EQ(row->getDoubleVector3("fixed_list", expectedVector), expectedVector);
+  EXPECT_EQ(row->getVector3<double>("fixed_list", expectedVector), expectedVector);
 }
 
 TEST_F(RowTest, isValid) {

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
@@ -74,9 +74,9 @@ class LineLayer::Props : public Layer::Props {
 
   /// Property accessors
   std::function<ArrowMapper::Vector3FloatAccessor> getSourcePosition{
-      [](const Row& row) { return row.getFloatVector3("sourcePosition"); }};
+      [](const Row& row) { return row.getVector3<float>("sourcePosition"); }};
   std::function<ArrowMapper::Vector3FloatAccessor> getTargetPosition{
-      [](const Row& row) { return row.getFloatVector3("targetPosition"); }};
+      [](const Row& row) { return row.getVector3<float>("targetPosition"); }};
   std::function<ArrowMapper::Vector4FloatAccessor> getColor{
       [](const Row&) { return mathgl::Vector4<float>(0.0, 0.0, 0.0, 255.0); }};
   std::function<ArrowMapper::FloatAccessor> getWidth{[](const Row&) { return 1.0; }};

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
@@ -81,7 +81,7 @@ class ScatterplotLayer::Props : public Layer::Props {
 
   /// Property accessors
   std::function<ArrowMapper::Vector3FloatAccessor> getPosition{
-      [](const Row& row) { return row.getFloatVector3("position"); }};
+      [](const Row& row) { return row.getVector3<float>("position"); }};
   std::function<ArrowMapper::FloatAccessor> getRadius{[](const Row&) { return 1.0; }};
   std::function<ArrowMapper::Vector4FloatAccessor> getFillColor{
       [](const Row&) { return mathgl::Vector4<float>(0.0, 0.0, 0.0, 255.0); }};


### PR DESCRIPTION
This seemed like a pitfall for anyone starting fresh -- all the data loaded through arrow loader would end up using doubles, while in our accessors we're always requesting floats. Current implementation requires ugly casting, or even worse returning the implicit default value without it.

Not sure whether this is the best implementation out there, but it gets rid of ~250 lines of boilerplate code that was in there before.