### PR TITLE
Fix some warnings from GCC

### DIFF
--- a/cpp/examples/luma.gl/animometer.cc
+++ b/cpp/examples/luma.gl/animometer.cc
@@ -148,7 +148,7 @@ int main(int argc, const char* argv[]) {
     static int f = 0;
     f++;
 
-    for (auto i = 0; i < uniforms.size(); ++i) {
+    for (size_t i = 0; i < uniforms.size(); ++i) {
       // Update buffer
       shaderData[i].time = f / 60.0f;
       uniforms[i]->buffer().SetSubData(0, sizeof(ShaderData), &(shaderData[i]));

--- a/cpp/modules/deck.gl/core/test/lib/view-manager-test.cpp
+++ b/cpp/modules/deck.gl/core/test/lib/view-manager-test.cpp
@@ -77,19 +77,19 @@ TEST(ViewManager, SetViews) {
   // Setting view causes redraw
   viewManager->setViews({view1});
   EXPECT_TRUE(viewManager->getNeedsRedraw(true));
-  EXPECT_EQ(1, viewManager->getViews().size());
+  EXPECT_EQ(size_t{1}, viewManager->getViews().size());
   // Same view does not cause redraw
   viewManager->setViews({view1});
   EXPECT_FALSE(viewManager->getNeedsRedraw());
-  EXPECT_EQ(1, viewManager->getViews().size());
+  EXPECT_EQ(size_t{1}, viewManager->getViews().size());
   // Adding a view causes redraw
   viewManager->setViews({view1, view2});
   EXPECT_TRUE(viewManager->getNeedsRedraw(true));
-  EXPECT_EQ(2, viewManager->getViews().size());
+  EXPECT_EQ(size_t{2}, viewManager->getViews().size());
   // Ordering matters
   viewManager->setViews({view2, view1});
   EXPECT_TRUE(viewManager->getNeedsRedraw(true));
-  EXPECT_EQ(2, viewManager->getViews().size());
+  EXPECT_EQ(size_t{2}, viewManager->getViews().size());
 
   EXPECT_EQ(view2, *(viewManager->getViews().begin()));
   EXPECT_EQ(view1, *(++(viewManager->getViews().begin())));

--- a/cpp/modules/deck.gl/json/test/json-converter-test.cpp
+++ b/cpp/modules/deck.gl/json/test/json-converter-test.cpp
@@ -86,7 +86,7 @@ TEST_F(JSONConverterTest, JSONConverterDeck) {
   EXPECT_TRUE(deckProps);
 
   // Test deckProps.layers
-  EXPECT_EQ(deckProps->layers.size(), 2);
+  EXPECT_EQ(deckProps->layers.size(), size_t{2});
 
   auto layer0Props = deckProps->layers.front();
   EXPECT_TRUE(layer0Props);

--- a/cpp/modules/luma.gl/garrow/src/util/arrow-utils.cc
+++ b/cpp/modules/luma.gl/garrow/src/util/arrow-utils.cc
@@ -96,6 +96,7 @@ auto arrowTypeFromVertexFormat(wgpu::VertexFormat format) -> std::shared_ptr<arr
     case Format::Int4:
       return arrow::fixed_size_list(arrow::int32(), 4);
   }
+  throw std::logic_error("Invalid vertex format");
 }
 
 auto vertexFormatFromArrowType(const std::shared_ptr<arrow::DataType>& type) -> std::optional<wgpu::VertexFormat> {

--- a/cpp/modules/luma.gl/garrow/src/util/webgpu-utils.cc
+++ b/cpp/modules/luma.gl/garrow/src/util/webgpu-utils.cc
@@ -20,6 +20,8 @@
 
 #include "./webgpu-utils.h"  // NOLINT(build/include)
 
+#include <stdexcept>
+
 namespace lumagl {
 namespace garrow {
 
@@ -72,6 +74,7 @@ auto getVertexFormatSize(wgpu::VertexFormat format) -> size_t {
     case Format::Int4:
       return 16;
   }
+  throw std::logic_error("Invalid vertex format");
 }
 
 }  // namespace garrow


### PR DESCRIPTION
Fixed warnings about comparison between int/size_t, and added logic_error to functions that should always return.