### PR TITLE
Implemented ScatterplotLayer

### DIFF
--- a/cpp/examples/deck.gl/flight-paths.cc
+++ b/cpp/examples/deck.gl/flight-paths.cc
@@ -43,33 +43,26 @@ auto createViewState(double bearing) -> std::shared_ptr<ViewState> {
 }
 
 auto createLineLayer(const std::string &dataPath) -> std::shared_ptr<LineLayer::Props> {
-  auto lineLayerProps = std::make_shared<LineLayer::Props>();
-  lineLayerProps->id = "flight-paths";
-  lineLayerProps->opacity = 0.8f;
-  lineLayerProps->getSourcePosition = [](const Row &row) -> mathgl::Vector3<float> {
-    return row.getVector3<float>("start");
-  };
-  lineLayerProps->getTargetPosition = [](const Row &row) -> mathgl::Vector3<float> {
-    return row.getVector3<float>("end");
-  };
-  lineLayerProps->getColor = [](const Row &row) -> mathgl::Vector4<float> {
-    float z = row.getVector3<float>("start").z;
-    float r = z / 10000.0f;
+  auto props = std::make_shared<LineLayer::Props>();
+  props->id = "flight-paths";
+  props->opacity = 0.8f;
+  props->getSourcePosition = [](const Row &row) { return row.getVector3<float>("start"); };
+  props->getTargetPosition = [](const Row &row) { return row.getVector3<float>("end"); };
+  props->getColor = [](const Row &row) -> mathgl::Vector4<float> {
+    float r = row.getVector3<float>("start").z / 10000.0f;
     return {255.0f * (1.0f - r * 2.0f), 128.0f * r, 255.0f * r, 255.0f * (1.0f - r)};
   };
-  lineLayerProps->getWidth = [](const Row &row) -> float { return 3.0f; };
-  lineLayerProps->data = jsonLoader.loadTable(fileSystem->OpenInputStream(dataPath).ValueOrDie());
+  props->getWidth = [](const Row &row) { return 3.0f; };
+  props->data = jsonLoader.loadTable(fileSystem->OpenInputStream(dataPath).ValueOrDie());
 
-  return lineLayerProps;
+  return props;
 }
 
 auto createScatterplotLayer(const std::string &dataPath) -> std::shared_ptr<ScatterplotLayer::Props> {
-  auto scatterplotLayerProps = std::make_shared<ScatterplotLayer::Props>();
-  scatterplotLayerProps->id = "airports";
-  scatterplotLayerProps->getPosition = [](const Row &row) -> mathgl::Vector3<float> {
-    return row.getVector3<float>("coordinates");
-  };
-  scatterplotLayerProps->getRadius = [](const Row &row) -> float {
+  auto props = std::make_shared<ScatterplotLayer::Props>();
+  props->id = "airports";
+  props->getPosition = [](const Row &row) { return row.getVector3<float>("coordinates"); };
+  props->getRadius = [](const Row &row) -> float {
     auto type = row.getString("type");
     if (type == "major") {
       return 100.0f;
@@ -79,13 +72,15 @@ auto createScatterplotLayer(const std::string &dataPath) -> std::shared_ptr<Scat
       return 60.0f;
     }
   };
-  scatterplotLayerProps->getFillColor = [](const Row &row) -> mathgl::Vector4<float> {
-    return mathgl::Vector4<float>{255.0f, 144.0f, 0.0f, 255.0f};
-  };
-  scatterplotLayerProps->radiusScale = 20.0f;
-  scatterplotLayerProps->data = jsonLoader.loadTable(fileSystem->OpenInputStream(dataPath).ValueOrDie());
+  props->getFillColor = [](const Row &row) { return mathgl::Vector4<float>{255.0f, 144.0f, 0.0f, 255.0f}; };
+  props->radiusScale = 20.0f;
+  props->stroked = true;
+  props->getLineWidth = [](const Row &row) { return 5.0f; };
+  props->getLineColor = [](const Row &row) { return mathgl::Vector4<float>{255.0f, 0.0f, 0.0f, 255.0f}; };
 
-  return scatterplotLayerProps;
+  props->data = jsonLoader.loadTable(fileSystem->OpenInputStream(dataPath).ValueOrDie());
+
+  return props;
 }
 
 int main(int argc, const char *argv[]) {

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer-vertex.glsl.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer-vertex.glsl.h
@@ -38,6 +38,7 @@ layout(std140, set = 0, binding = 1) uniform LineLayerOptions {
 } layerOptions;
 
 layout(location = 0) in vec3 positions;
+
 layout(location = 1) in vec3 instanceSourcePositions;
 layout(location = 2) in vec3 instanceTargetPositions;
 layout(location = 3) in vec4 instanceColors;
@@ -90,7 +91,7 @@ void main(void) {
 
   // Color
   vec4 color = vec4(instanceColors.rgb, instanceColors.a * layerOptions.opacity);
-// Normalize the values
+  // Normalize the values
   vColor = clamp(color, 0, 255) / 255.0;
 }
 )GLSL";

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -75,34 +75,46 @@ void LineLayer::initializeState() {
   auto getWidth = std::bind(&LineLayer::getWidthData, this, std::placeholders::_1);
   this->attributeManager->add(garrow::ColumnBuilder{width, getWidth});
 
-  // TODO(ilija@unfolded.ai): Where should we initialize models?
   this->models = {this->_getModel(this->context->device)};
+  this->_layerUniforms = std::make_shared<garrow::Array>(this->context->device);
 }
 
 void LineLayer::updateState(const Layer::ChangeFlags& changeFlags, const Layer::Props* oldProps) {
-  // super::updateState(props, oldProps, changeFlags);
+  super::updateState(changeFlags, oldProps);
 
-  // if (changeFlags.extensionsChanged) {
-  //   const {gl} = this->context;
-  //   if (this->state->model) {
-  //     this->state->model;
-  //   }
-  //   this->setState({model: this->_getModel(gl)});
-  //   this->getAttributeManager().invalidateAll();
-  // }
+  auto props = std::dynamic_pointer_cast<LineLayer::Props>(this->props());
+  float widthMultiplier = props->widthUnits == "pixels" ? this->context->viewport->metersPerPixel() : 1.0;
+  LineLayerUniforms layerUniforms;
+  layerUniforms.opacity = props->opacity;
+  layerUniforms.widthScale = props->widthScale * widthMultiplier;
+  layerUniforms.widthMinPixels = props->widthMinPixels;
+  layerUniforms.widthMaxPixels = props->widthMaxPixels;
+
+  this->_layerUniforms->setData(&layerUniforms, 1, wgpu::BufferUsage::Uniform);
+
+  /*
+  super::updateState(props, oldProps, changeFlags);
+
+  if (changeFlags.extensionsChanged) {
+    const {gl} = this->context;
+    if (this->state->model) {
+      this->state->model;
+    }
+    this->setState({model: this->_getModel(gl)});
+    this->getAttributeManager().invalidateAll();
+  }
+  */
 }
 
 void LineLayer::finalizeState() {}
 
 void LineLayer::drawState(wgpu::RenderPassEncoder pass) {
-  auto props = std::dynamic_pointer_cast<LineLayer::Props>(this->props());
-  float widthMultiplier = props->widthUnits == "pixels" ? this->context->viewport->metersPerPixel() : 1.0;
-  auto widthScale = props->widthScale * widthMultiplier;
-  LineLayerUniforms layerUniforms{props->opacity, widthScale, props->widthMinPixels, props->widthMaxPixels};
+  // TODO(ilija@unfolded.ai): Remove. updateState currently doesn't seem to be called when viewport changes
+  this->updateState(Layer::ChangeFlags{}, nullptr);
+
   for (auto const& model : this->getModels()) {
     // Layer uniforms are currently bound to index 1
-    model->setUniforms(
-        std::make_shared<garrow::Array>(this->context->device, &layerUniforms, 1, wgpu::BufferUsage::Uniform), 1);
+    model->setUniforms(this->_layerUniforms, 1);
     model->draw(pass);
   }
 }

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -30,10 +30,10 @@ using namespace deckgl;
 using namespace lumagl;
 
 const std::vector<const Property*> propTypeDefs = {
-    //  new PropertyT<std::string>{"widthUnits",
-    //      [](const JSONObject* props) { return dynamic_cast<const LineLayer*>(props)->widthUnits; },
-    //      [](JSONObject* props, bool value) { return dynamic_cast<LineLayer*>(props)->widthUnits = value; },
-    //      true},
+    new PropertyT<std::string>{
+        "widthUnits", [](const JSONObject* props) { return dynamic_cast<const LineLayer::Props*>(props)->widthUnits; },
+        [](JSONObject* props, std::string value) { return dynamic_cast<LineLayer::Props*>(props)->widthUnits = value; },
+        "pixels"},
     new PropertyT<float>{
         "widthScale", [](const JSONObject* props) { return dynamic_cast<const LineLayer::Props*>(props)->widthScale; },
         [](JSONObject* props, float value) { return dynamic_cast<LineLayer::Props*>(props)->widthScale = value; }, 1.0},
@@ -105,23 +105,6 @@ void LineLayer::drawState(wgpu::RenderPassEncoder pass) {
         std::make_shared<garrow::Array>(this->context->device, &layerUniforms, 1, wgpu::BufferUsage::Uniform), 1);
     model->draw(pass);
   }
-
-  /*
-  const {viewport} = this->context;
-  const {widthUnits, widthScale, widthMinPixels, widthMaxPixels} = ;
-
-  const widthMultiplier = widthUnits === 'pixels' ? viewport.metersPerPixel :
-
-  this->state.model
-    .setUniforms(
-      Object.assign({}, uniforms, {
-        widthScale: widthScale * widthMultiplier,
-        widthMinPixels,
-        widthMaxPixels
-      })
-    )
-    .draw();
-  */
 }
 
 auto LineLayer::_getModel(wgpu::Device device) -> std::shared_ptr<lumagl::Model> {

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
@@ -67,10 +67,10 @@ class LineLayer::Props : public Layer::Props {
     return new LineLayer{std::dynamic_pointer_cast<LineLayer::Props>(props)};
   }
 
-  std::string widthUnits{"pixels"};                         // 'pixels',
-  float widthScale{1};                                      // {type: 'number', value: 1, min: 0},
-  float widthMinPixels{0};                                  // {type: 'number', value: 0, min: 0},
-  float widthMaxPixels{std::numeric_limits<float>::max()};  // {type: 'number', value: Number.MAX_SAFE_INTEGER, min: 0}
+  std::string widthUnits{"pixels"};
+  float widthScale{1};
+  float widthMinPixels{0};
+  float widthMaxPixels{std::numeric_limits<float>::max()};
 
   /// Property accessors
   std::function<ArrowMapper::Vector3FloatAccessor> getSourcePosition{
@@ -82,6 +82,7 @@ class LineLayer::Props : public Layer::Props {
   std::function<ArrowMapper::FloatAccessor> getWidth{[](const Row&) { return 1.0; }};
 };
 
+/// The order of fields in this structure is crucial for it to be mapped to its GLSL counterpart properly.
 struct LineLayerUniforms {
   float opacity;
   float widthScale;

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
@@ -29,12 +29,15 @@
 #include <string>
 
 #include "deck.gl/core.h"
+#include "luma.gl/garrow.h"
 #include "luma.gl/webgpu.h"
 
 namespace deckgl {
 
 class LineLayer : public Layer {
  public:
+  using super = Layer;
+
   class Props;
   explicit LineLayer(std::shared_ptr<LineLayer::Props> props) : Layer{std::dynamic_pointer_cast<Layer::Props>(props)} {}
   auto props() { return std::dynamic_pointer_cast<Layer::Props>(this->_props); }
@@ -54,6 +57,8 @@ class LineLayer : public Layer {
 
  private:
   auto _getModel(wgpu::Device) -> std::shared_ptr<lumagl::Model>;
+
+  std::shared_ptr<lumagl::garrow::Array> _layerUniforms;
 };
 
 class LineLayer::Props : public Layer::Props {

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
@@ -20,8 +20,8 @@
 
 #include "./scatterplot-layer.h"  // NOLINT(build/include)
 
-// #include "./scatterplot-layer-fragment.glsl.h"
-// #include "./scatterplot-layer-vertex.glsl.h"
+#include "./scatterplot-layer-fragment.glsl.h"
+#include "./scatterplot-layer-vertex.glsl.h"
 #include "deck.gl/core.h"
 
 using namespace deckgl;
@@ -36,10 +36,13 @@ const std::vector<const Property*> propTypeDefs = {
         "stroked", [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->stroked; },
         [](JSONObject* props, bool value) { return dynamic_cast<ScatterplotLayer::Props*>(props)->stroked = value; },
         false},
-    // new PropertyT<std::string>{"lineWidthUnits",
-    //     [](const JSONObject* props) { return dynamic_cast<ScatterplotLayer::Props *>(props)->widthUnits; },
-    //     [](JSONObject* props, bool value) { return dynamic_cast<ScatterplotLayer::Props
-    //     *>(props)->widthUnits = value; }, true}},
+    new PropertyT<std::string>{
+        "lineWidthUnits",
+        [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->lineWidthUnits; },
+        [](JSONObject* props, std::string value) {
+          return dynamic_cast<ScatterplotLayer::Props*>(props)->lineWidthUnits = value;
+        },
+        "meters"},
     new PropertyT<float>{
         "lineWidthScale",
         [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->lineWidthScale; },
@@ -89,35 +92,6 @@ auto ScatterplotLayer::Props::getProperties() const -> const Properties* {
   return &properties;
 }
 
-/*
-const DEFAULT_COLOR = [0, 0, 0, 255];
-
-const defaultProps = {
-  radiusScale: {type: 'number', min: 0, value: 1},
-  radiusMinPixels: {type: 'number', min: 0, value: 0}, //  min point radius in
-pixels radiusMaxPixels: {type: 'number', min: 0, value:
-Number.MAX_SAFE_INTEGER}, // max point radius in pixels
-
-  lineWidthUnits: 'meters',
-  lineWidthScale: {type: 'number', min: 0, value: 1},
-  lineWidthMinPixels: {type: 'number', min: 0, value: 0},
-  lineWidthMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER},
-
-  stroked: false,
-  filled: true,
-
-  getPosition: {type: 'accessor', value: x => x.position},
-  getRadius: {type: 'accessor', value: 1},
-  getFillColor: {type: 'accessor', value: DEFAULT_COLOR},
-  getLineColor: {type: 'accessor', value: DEFAULT_COLOR},
-  getLineWidth: {type: 'accessor', value: 1},
-};
-*/
-
-// auto ScatterplotLayer::getShaders(id) {
-//   return super.getShaders({vs, fs, modules: [project32, picking]});
-// }
-
 void ScatterplotLayer::initializeState() {
   // TODO(ilija@unfolded.ai): Guaranteed to crash when this layer goes out of scope, revisit
   // TODO(ilija@unfolded.ai): Revisit type once double precision is in place
@@ -140,6 +114,9 @@ void ScatterplotLayer::initializeState() {
   auto lineWidth = std::make_shared<arrow::Field>("instanceLineWidths", arrow::float32());
   auto getLineWidth = std::bind(&ScatterplotLayer::getLineWidthData, this, std::placeholders::_1);
   this->attributeManager->add(garrow::ColumnBuilder{lineWidth, getLineWidth});
+
+  // TODO(ilija@unfolded.ai): Where should we initialize models?
+  this->models = {this->_getModel(this->context->device)};
 }
 
 void ScatterplotLayer::updateState(const Layer::ChangeFlags& changeFlags, const Layer::Props* oldProps) {
@@ -158,38 +135,21 @@ void ScatterplotLayer::updateState(const Layer::ChangeFlags& changeFlags, const 
 
 void ScatterplotLayer::finalizeState() {}
 
-void ScatterplotLayer::drawState(wgpu::RenderPassEncoder pass) {  // uniforms
-  /*
-    const {viewport} = this->context;
-    const {
-      radiusScale,
-      radiusMinPixels,
-      radiusMaxPixels,
-      stroked,
-      filled,
-      lineWidthUnits,
-      lineWidthScale,
-      lineWidthMinPixels,
-      lineWidthMaxPixels
-    } = this->props;
+void ScatterplotLayer::drawState(wgpu::RenderPassEncoder pass) {
+  auto props = std::dynamic_pointer_cast<ScatterplotLayer::Props>(this->props());
+  float widthMultiplier = props->lineWidthUnits == "pixels" ? this->context->viewport->metersPerPixel() : 1.0;
+  auto lineWidthScale = props->lineWidthScale * widthMultiplier;
 
-    const widthMultiplier = lineWidthUnits === 'pixels' ?
-      viewport.metersPerPixel : 1;
-
-    this->state.model
-      .setUniforms(uniforms)
-      .setUniforms({
-        stroked: stroked ? 1 : 0,
-        filled,
-        radiusScale,
-        radiusMinPixels,
-        radiusMaxPixels,
-        lineWidthScale: lineWidthScale * widthMultiplier,
-        lineWidthMinPixels,
-        lineWidthMaxPixels
-      })
-      .draw();
-    */
+  ScatterplotLayerUniforms layerUniforms{
+      props->opacity, props->radiusScale,        props->radiusMinPixels,    props->radiusMaxPixels,
+      lineWidthScale, props->lineWidthMinPixels, props->lineWidthMaxPixels, props->stroked ? 1.0f : 0.0f,
+      props->filled};
+  for (auto const& model : this->getModels()) {
+    // Layer uniforms are currently bound to index 1
+    model->setUniforms(
+        std::make_shared<garrow::Array>(this->context->device, &layerUniforms, 1, wgpu::BufferUsage::Uniform), 1);
+    model->draw(pass);
+  }
 }
 
 auto ScatterplotLayer::getPositionData(const std::shared_ptr<arrow::Table>& table) -> std::shared_ptr<arrow::Array> {
@@ -238,20 +198,43 @@ auto ScatterplotLayer::getLineWidthData(const std::shared_ptr<arrow::Table>& tab
 }
 
 auto ScatterplotLayer::_getModel(wgpu::Device device) -> std::shared_ptr<lumagl::Model> {
-  // a square that minimally cover the unit circle
-  // const positions = [ -1, -1, 0, -1, 1, 0, 1, 1, 0, 1, -1, 0 ];
+  std::vector<std::shared_ptr<garrow::Field>> attributeFields{
+      std::make_shared<garrow::Field>("positions", wgpu::VertexFormat::Float3)};
+  auto attributeSchema = std::make_shared<lumagl::garrow::Schema>(attributeFields);
 
-  auto devicePtr = std::make_shared<wgpu::Device>(std::move(device));
-  return nullptr;  // std::shared_ptr<lumagl::Model>(new lumagl::Model(devicePtr));
-  // Object.assign(this->getShaders(), {
-  //   id: this->props.id,
-  //   geometry: new Geometry({
-  //     drawMode: GL.TRIANGLE_FAN,
-  //     vertexCount: 4,
-  //     attributes: {
-  //       positions: {size: 3, value: new Float32Array(positions)}
-  //     }
-  //   }),
-  //   isInstanced: true
-  // })
+  // TODO(ilija@unfolded.ai): **arrow**::Fields are already being specified in initializeState, consolidate?
+  std::vector<std::shared_ptr<garrow::Field>> instancedFields{
+      std::make_shared<garrow::Field>("instancePositions", wgpu::VertexFormat::Float3),
+      std::make_shared<garrow::Field>("instanceRadius", wgpu::VertexFormat::Float),
+      std::make_shared<garrow::Field>("instanceFillColors", wgpu::VertexFormat::Float4),
+      std::make_shared<garrow::Field>("instanceLineColors", wgpu::VertexFormat::Float4),
+      std::make_shared<garrow::Field>("instanceLineWidths", wgpu::VertexFormat::Float)};
+  auto instancedAttributeSchema = std::make_shared<lumagl::garrow::Schema>(instancedFields);
+
+  std::vector<UniformDescriptor> uniforms = {
+      {sizeof(ViewportUniforms)},
+      {sizeof(ScatterplotLayerUniforms), wgpu::ShaderStage::Vertex | wgpu::ShaderStage::Fragment}};
+  auto modelOptions = Model::Options{
+      vs, fs, attributeSchema, instancedAttributeSchema, uniforms, wgpu::PrimitiveTopology::TriangleStrip};
+  auto model = std::make_shared<lumagl::Model>(device, modelOptions);
+
+  // A square that minimally covers the unit circle
+  //
+  //  (-1, -1)_------------_(1, -1)
+  //        |  "-,_          |
+  //        o      "-,_      o
+  //        |          "-,_  |
+  //  (-1, 1)"-------------"(1, 1)
+  //
+  std::vector<mathgl::Vector3<float>> positionData = {{-1, 1, 0}, {-1, -1, 0}, {1, 1, 0}, {1, -1, 0}};
+  std::vector<std::shared_ptr<garrow::Array>> attributeArrays{
+      std::make_shared<garrow::Array>(this->context->device, positionData, wgpu::BufferUsage::Vertex)};
+  model->setAttributes(std::make_shared<garrow::Table>(attributeSchema, attributeArrays));
+
+  auto instancedAttributes = this->attributeManager->update(this->props()->data);
+  model->setInstancedAttributes(instancedAttributes);
+
+  model->vertexCount = static_cast<int>(positionData.size());
+
+  return model;
 }

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
@@ -21,13 +21,11 @@
 #ifndef DECKGL_LAYERS_SCATTERPLOT_LAYER_H
 #define DECKGL_LAYERS_SCATTERPLOT_LAYER_H
 
+#include <limits>
 #include <memory>
 #include <string>
 
-#include "deck.gl/core.h"  // import {Layer, project32, picking} from '@deck.gl/core';
-
-// import GL from '@luma.gl/constants';
-// import {Model, Geometry} from '@luma.gl/core';
+#include "deck.gl/core.h"
 
 namespace deckgl {
 
@@ -71,13 +69,13 @@ class ScatterplotLayer::Props : public Layer::Props {
   bool stroked{false};
 
   std::string lineWidthUnits{"meters"};
-  float lineWidthScale{1.0};      //
-  float lineWidthMinPixels{1.0};  // min point radius in pixels
-  float lineWidthMaxPixels{2.0};  // max point radius in pixels
+  float lineWidthScale{1.0};
+  float lineWidthMinPixels{0.0};
+  float lineWidthMaxPixels{std::numeric_limits<float>::max()};
 
   float radiusScale{1.0};
-  float radiusMinPixels{1.0};  // min point radius in pixels
-  float radiusMaxPixels{2.0};  // max point radius in pixels
+  float radiusMinPixels{0.0};                                // min point radius in pixels
+  float radiusMaxPixels{std::numeric_limits<float>::max()};  // max point radius in pixels
 
   /// Property accessors
   std::function<ArrowMapper::Vector3FloatAccessor> getPosition{
@@ -88,6 +86,21 @@ class ScatterplotLayer::Props : public Layer::Props {
   std::function<ArrowMapper::Vector4FloatAccessor> getLineColor{
       [](const Row&) { return mathgl::Vector4<float>(0.0, 0.0, 0.0, 255.0); }};
   std::function<ArrowMapper::FloatAccessor> getLineWidth{[](auto row) { return 1.0; }};
+};
+
+/// The order of fields in this structure is crucial for it to be mapped to its GLSL counterpart properly.
+/// bool has a 4-byte alignment in GLSL.
+/// https://learnopengl.com/Advanced-OpenGL/Advanced-GLSL
+struct ScatterplotLayerUniforms {
+  float opacity;
+  float radiusScale;
+  float radiusMinPixels;
+  float radiusMaxPixels;
+  float lineWidthScale;
+  float lineWidthMinPixels;
+  float lineWidthMaxPixels;
+  float stroked;
+  alignas(4) bool filled;
 };
 
 }  // namespace deckgl

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
@@ -26,11 +26,15 @@
 #include <string>
 
 #include "deck.gl/core.h"
+#include "luma.gl/garrow.h"
+#include "luma.gl/webgpu.h"
 
 namespace deckgl {
 
 class ScatterplotLayer : public Layer {
  public:
+  using super = Layer;
+
   class Props;
   explicit ScatterplotLayer(std::shared_ptr<ScatterplotLayer::Props> props)
       : Layer{std::dynamic_pointer_cast<Layer::Props>(props)} {}
@@ -52,6 +56,8 @@ class ScatterplotLayer : public Layer {
 
  private:
   auto _getModel(wgpu::Device device) -> std::shared_ptr<lumagl::Model>;
+
+  std::shared_ptr<lumagl::garrow::Array> _layerUniforms;
 };
 
 class ScatterplotLayer::Props : public Layer::Props {

--- a/cpp/modules/luma.gl/core/src/model.cpp
+++ b/cpp/modules/luma.gl/core/src/model.cpp
@@ -152,7 +152,7 @@ auto Model::_createBindGroupLayout(wgpu::Device device, const std::vector<Unifor
     -> wgpu::BindGroupLayout {
   std::vector<wgpu::BindGroupLayoutBinding> bindings;
   for (uint32_t i = 0; i < uniforms.size(); i++) {
-    auto binding = wgpu::BindGroupLayoutBinding{i, wgpu::ShaderStage::Vertex, wgpu::BindingType::UniformBuffer,
+    auto binding = wgpu::BindGroupLayoutBinding{i, uniforms[i].shaderStage, wgpu::BindingType::UniformBuffer,
                                                 uniforms[i].isDynamic};
     bindings.push_back(binding);
   }

--- a/cpp/modules/luma.gl/core/src/model.h
+++ b/cpp/modules/luma.gl/core/src/model.h
@@ -38,7 +38,13 @@ struct AttributePropertyKeys {};
 
 // TODO(ilija@unfolded.ai): Move out and revisit
 struct UniformDescriptor {
+ public:
+  UniformDescriptor(size_t elementSize, wgpu::ShaderStage shaderStage = wgpu::ShaderStage::Vertex,
+                    bool isDynamic = false)
+      : elementSize{elementSize}, shaderStage{shaderStage}, isDynamic{isDynamic} {}
+
   size_t elementSize;
+  wgpu::ShaderStage shaderStage;
   bool isDynamic{false};
 };
 

--- a/cpp/modules/luma.gl/garrow/src/array.cc
+++ b/cpp/modules/luma.gl/garrow/src/array.cc
@@ -43,9 +43,9 @@ void Array::setData(const std::shared_ptr<arrow::Array>& data, wgpu::BufferUsage
   auto vertexFormat = vertexFormatOptional.value();
   auto vertexSize = getVertexFormatSize(vertexFormat);
 
-  if (!this->_buffer || data->length() != this->_length) {
-    auto byteLength = vertexSize * data->length();
-    this->_buffer = this->_createBuffer(this->_device, byteLength, usage);
+  auto bufferByteSize = vertexSize * data->length();
+  if (!this->_buffer || bufferByteSize != this->_bufferByteSize) {
+    this->_buffer = this->_createBuffer(this->_device, bufferByteSize, usage);
   }
 
   // TODO(ilija@unfolded.ai): Handle arrays with null values correctly
@@ -73,6 +73,7 @@ void Array::setData(const std::shared_ptr<arrow::Array>& data, wgpu::BufferUsage
   }
 
   this->_length = data->length();
+  this->_bufferByteSize = bufferByteSize;
 }
 
 auto Array::_createBuffer(wgpu::Device device, uint64_t size, wgpu::BufferUsage usage) -> wgpu::Buffer {


### PR DESCRIPTION
Two things that I had to cover that are specific to this layer:
- It's using layer uniforms in the fragment shader, so I've added support for specifying the stage uniforms should be bound in
- It was using triangle fan which doesn't seem to be supported in WebGPU. I've converted the points so that they define the same geometry using triangle strips

That being said I don't think these look the way they're supposed to look, they seem to be squares instead of circles that I'm seeing on the web. Also, when zooming in very closely, they seem to stop scaling at some point. I'm seeing weird geometry in the geometry inspector (could just be a bug in the tool, it's pretty flimsy sometimes) although all of the values seem valid, no NaNs or anything.

I also did not test the line component, are there any examples that make use of it?

<img width="1437" alt="Screen Shot 2020-05-02 at 14 37 30" src="https://user-images.githubusercontent.com/3406718/80858178-302f4080-8c8a-11ea-8954-f812b6e3955a.png">
<img width="180" alt="Screen Shot 2020-05-02 at 15 01 58" src="https://user-images.githubusercontent.com/3406718/80858180-345b5e00-8c8a-11ea-83fc-e93f0fcf384e.png">
