### PR TITLE
Blending enabled, opacity fix

### DIFF
--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer-vertex.glsl.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer-vertex.glsl.h
@@ -90,9 +90,8 @@ void main(void) {
   gl_Position = p + vec4(project_pixel_size_to_clipspace(offset.xy), 0.0, 0.0);
 
   // Color
-  vec4 color = vec4(instanceColors.rgb, instanceColors.a * layerOptions.opacity);
-  // Normalize the values
-  vColor = clamp(color, 0, 255) / 255.0;
+  vec4 normalizedInstanceColors = clamp(instanceColors, 0, 255) / 255.0;
+  vColor = vec4(normalizedInstanceColors.rgb, normalizedInstanceColors.a * layerOptions.opacity);
 }
 )GLSL";
 

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.h
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer-vertex.glsl.h
@@ -87,8 +87,10 @@ void main(void) {
   gl_Position = project_position_to_clipspace(instancePositions, instancePositions64Low, offset, geometry.position);
 
   // Apply opacity to instance color, or return instance picking color, then normalize the values
-  vFillColor = clamp(vec4(instanceFillColors.rgb, instanceFillColors.a * layerOptions.opacity), 0, 255) / 255.0;
-  vLineColor = clamp(vec4(instanceLineColors.rgb, instanceLineColors.a * layerOptions.opacity), 0, 255) / 255.0;
+  vec4 normalizedFillColors = clamp(instanceFillColors, 0, 255) / 255.0;
+  vFillColor = vec4(normalizedFillColors.rgb, normalizedFillColors.a * layerOptions.opacity);
+  vec4 normalizedLineColors = clamp(instanceLineColors, 0, 255) / 255.0;
+  vLineColor = vec4(normalizedLineColors.rgb, normalizedLineColors.a * layerOptions.opacity);
 }
 )GLSL";
 

--- a/cpp/modules/luma.gl/core/src/model.cpp
+++ b/cpp/modules/luma.gl/core/src/model.cpp
@@ -41,7 +41,12 @@ Model::Model(wgpu::Device device, const Model::Options& options) {
   descriptor.vertexStage.module = this->vsModule;
   descriptor.cFragmentStage.module = this->fsModule;
   descriptor.primitiveTopology = options.primitiveTopology;
+
   descriptor.cColorStates[0].format = options.textureFormat;
+  descriptor.cColorStates[0].colorBlend.srcFactor = wgpu::BlendFactor::SrcAlpha;
+  descriptor.cColorStates[0].colorBlend.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
+  descriptor.cColorStates[0].alphaBlend.srcFactor = wgpu::BlendFactor::One;
+  descriptor.cColorStates[0].alphaBlend.dstFactor = wgpu::BlendFactor::Zero;
 
   this->_initializeVertexState(&descriptor.cVertexState, options.attributeSchema, options.instancedAttributeSchema);
 

--- a/cpp/modules/luma.gl/core/src/model.cpp
+++ b/cpp/modules/luma.gl/core/src/model.cpp
@@ -45,8 +45,8 @@ Model::Model(wgpu::Device device, const Model::Options& options) {
   descriptor.cColorStates[0].format = options.textureFormat;
   descriptor.cColorStates[0].colorBlend.srcFactor = wgpu::BlendFactor::SrcAlpha;
   descriptor.cColorStates[0].colorBlend.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
-  descriptor.cColorStates[0].alphaBlend.srcFactor = wgpu::BlendFactor::One;
-  descriptor.cColorStates[0].alphaBlend.dstFactor = wgpu::BlendFactor::Zero;
+  descriptor.cColorStates[0].alphaBlend.srcFactor = wgpu::BlendFactor::SrcAlpha;
+  descriptor.cColorStates[0].alphaBlend.dstFactor = wgpu::BlendFactor::OneMinusSrcAlpha;
 
   this->_initializeVertexState(&descriptor.cVertexState, options.attributeSchema, options.instancedAttributeSchema);
 


### PR DESCRIPTION
It looks like it doesn't need to be enabled explicitly, and the API is split into two components just like [glBlendFuncSeparate](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFuncSeparate.xhtml).

Not sure if these are the correct factors? Couldn't find what was commonly used in web version. We probably want to expose these so that the user can set them eventually, but this should hopefully be fine for now