### PR TITLE
Added the API that allows rendering Deck into a texture

### DIFF
--- a/cpp/examples/deck.gl/CMakeLists.txt
+++ b/cpp/examples/deck.gl/CMakeLists.txt
@@ -22,6 +22,7 @@ set(EXAMPLE_SOURCE_FILES
     stdinout.cpp
     flight-paths.cc
     manhattan-population.cc
+    texture-render.cc
     )
 set(EXAMPLE_DATA_FILES
     ${DECK_DATA_PATH}/examples/flight-paths/heathrow-flights.ndjson

--- a/cpp/examples/deck.gl/flight-paths.cc
+++ b/cpp/examples/deck.gl/flight-paths.cc
@@ -91,6 +91,7 @@ int main(int argc, const char *argv[]) {
   auto airportDataPath = programDirectory + "/data/airports.ndjson";
 
   auto deckProps = std::make_shared<Deck::Props>();
+  deckProps->id = "Heathrow Flights";
   deckProps->layers = {createLineLayer(flightDataPath), createScatterplotLayer(airportDataPath)};
   deckProps->initialViewState = createViewState(0.0);
   deckProps->views = {std::make_shared<MapView>()};

--- a/cpp/examples/deck.gl/texture-render.cc
+++ b/cpp/examples/deck.gl/texture-render.cc
@@ -101,12 +101,16 @@ int main(int argc, const char* argv[]) {
 
   auto framebufferSize = windowSize * animationLoop.devicePixelRatio();
 
-  // Create a Deck and draw into a newly created texture
   auto deck = createDeck(argv, device, windowSize);
   auto textureView = createTextureView(device, framebufferSize, animationLoop.getPreferredSwapChainTextureFormat());
-  deck->draw(textureView);
 
-  // Draw the texture onto the screen
-  BlitModel model{device, textureView, framebufferSize};
-  animationLoop.run([&](wgpu::RenderPassEncoder pass) { model.draw(pass); });
+  BlitModel blitModel{device, textureView, framebufferSize};
+  animationLoop.run([&](wgpu::RenderPassEncoder pass) {
+    static double bearing = 0.0;
+    deck->props()->viewState = createViewState(bearing -= 0.3);
+    deck->setProps(deck->props());
+
+    deck->draw(textureView);
+    blitModel.draw(pass);
+  });
 }

--- a/cpp/examples/deck.gl/texture-render.cc
+++ b/cpp/examples/deck.gl/texture-render.cc
@@ -18,15 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Port of https://github.com/visgl/deck.gl/tree/master/examples/website/scatterplot
-
 #include <arrow/filesystem/localfs.h>
+
+#include <limits>
 
 #include "deck.gl/core.h"
 #include "deck.gl/layers.h"
 #include "loaders.gl/json.h"
 
 using namespace deckgl;
+using namespace lumagl;
+
+// Deck setup taken from manhattan-population example
 
 loadersgl::JSONLoader jsonLoader;
 auto fileSystem = std::make_shared<arrow::fs::LocalFileSystem>();
@@ -45,21 +48,21 @@ auto createViewState(double bearing) -> std::shared_ptr<ViewState> {
   return viewState;
 }
 
-auto createScatterplotLayer(const std::string &dataPath) -> std::shared_ptr<ScatterplotLayer::Props> {
+auto createScatterplotLayer(const std::string& dataPath) -> std::shared_ptr<ScatterplotLayer::Props> {
   auto props = std::make_shared<ScatterplotLayer::Props>();
   props->id = "population";
   props->radiusScale = 30.0f;
   props->radiusMinPixels = 0.25f;
-  props->getPosition = [](const Row &row) { return row.getVector3<float>("pos"); };
-  props->getRadius = [](const Row &row) { return 1.0f; };
-  props->getFillColor = [](const Row &row) { return row.getInt("gender") == 1 ? maleColor : femaleColor; };
+  props->getPosition = [](const Row& row) { return row.getVector3<float>("pos"); };
+  props->getRadius = [](const Row& row) { return 1.0f; };
+  props->getFillColor = [](const Row& row) { return row.getInt("gender") == 1 ? maleColor : femaleColor; };
 
   props->data = jsonLoader.loadTable(fileSystem->OpenInputStream(dataPath).ValueOrDie());
 
   return props;
 }
 
-int main(int argc, const char *argv[]) {
+auto createDeck(const char* argv[], const wgpu::Device& device, const lumagl::Size& size) -> std::shared_ptr<Deck> {
   // Get data file paths relative to working directory
   auto programPath = std::string{argv[0]};
   auto programDirectory = programPath.erase(programPath.find_last_of("/"));
@@ -70,15 +73,40 @@ int main(int argc, const char *argv[]) {
   deckProps->layers = {createScatterplotLayer(populationDataPath)};
   deckProps->initialViewState = createViewState(0.0);
   deckProps->views = {std::make_shared<MapView>()};
-  deckProps->width = 640;
-  deckProps->height = 480;
+  deckProps->width = size.width;
+  deckProps->height = size.height;
 
-  auto deck = std::make_shared<Deck>(deckProps);
-  deck->run([&deckProps](Deck *deck) {
-    static double bearing = 0.0;
-    deckProps->viewState = createViewState(bearing += 0.3);
-    deck->setProps(deckProps);
-  });
+  deckProps->renderingOptions = Deck::RenderingOptions{device, device.CreateQueue(), false};
 
-  return 0;
+  return std::make_shared<Deck>(deckProps);
+}
+
+auto createTextureView(const wgpu::Device& device, const lumagl::Size& size, const wgpu::TextureFormat textureFormat)
+    -> wgpu::TextureView {
+  wgpu::TextureDescriptor descriptor;
+  descriptor.size.width = size.width;
+  descriptor.size.height = size.height;
+  descriptor.size.depth = 1;
+  descriptor.format = textureFormat;
+  descriptor.usage = wgpu::TextureUsage::Present | wgpu::TextureUsage::OutputAttachment | wgpu::TextureUsage::Sampled;
+  auto texture = device.CreateTexture(&descriptor);
+
+  return texture.CreateView();
+}
+
+int main(int argc, const char* argv[]) {
+  auto windowSize = lumagl::Size{640, 480};
+  GLFWAnimationLoop animationLoop{windowSize, "Texture Render"};
+  auto device = animationLoop.device();
+
+  auto framebufferSize = windowSize * animationLoop.devicePixelRatio();
+
+  // Create a Deck and draw into a newly created texture
+  auto deck = createDeck(argv, device, windowSize);
+  auto textureView = createTextureView(device, framebufferSize, animationLoop.getPreferredSwapChainTextureFormat());
+  deck->draw(textureView);
+
+  // Draw the texture onto the screen
+  BlitModel model{device, textureView, framebufferSize};
+  animationLoop.run([&](wgpu::RenderPassEncoder pass) { model.draw(pass); });
 }

--- a/cpp/examples/luma.gl/animometer.cc
+++ b/cpp/examples/luma.gl/animometer.cc
@@ -145,7 +145,6 @@ int main(int argc, const char* argv[]) {
   }
 
   model.setAttributes(attributes);
-  model.vertexCount = static_cast<int>(attributes->num_rows());
 
   animationLoop.run([&](wgpu::RenderPassEncoder pass) {
     static int f = 0;

--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -70,6 +70,7 @@ Deck::Deck(std::shared_ptr<Deck::Props> props)
 
   this->context->layerManager = this->layerManager;
 
+  // TODO(ilija@unfolded.ai): Delegate to project shader module
   this->_viewportUniformsBuffer =
       lumagl::utils::createBuffer(this->animationLoop->device(), sizeof(ViewportUniforms), wgpu::BufferUsage::Uniform);
 }
@@ -127,7 +128,7 @@ void Deck::run(std::function<void(Deck*)> onAfterRender) {
 
 void Deck::draw(wgpu::TextureView textureView, std::function<void(Deck*)> onAfterRender) {
   // TODO(ilija@unfolded.ai): We've got a retain cycle here, revisit
-  this->animationLoop->frame(textureView, [&](wgpu::RenderPassEncoder pass) { this->_draw(pass, onAfterRender); });
+  this->animationLoop->draw(textureView, [&](wgpu::RenderPassEncoder pass) { this->_draw(pass, onAfterRender); });
 }
 
 void Deck::stop() { this->animationLoop->stop(); }

--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -62,9 +62,16 @@ auto Deck::Props::getProperties() const -> const Properties* {
 
 Deck::Deck(std::shared_ptr<Deck::Props> props)
     : Component(props), width{props->width}, height{props->height}, _needsRedraw{"Initial render"} {
+  this->animationLoop = this->_createAnimationLoop(props);
+  this->context = std::make_shared<LayerContext>(this, this->animationLoop->device());
+  this->layerManager = std::make_shared<LayerManager>(this->context);
+
   this->setProps(props);
 
   this->context->layerManager = this->layerManager;
+
+  this->_viewportUniformsBuffer =
+      lumagl::utils::createBuffer(this->animationLoop->device(), sizeof(ViewportUniforms), wgpu::BufferUsage::Uniform);
 }
 
 Deck::~Deck() {
@@ -115,32 +122,15 @@ void Deck::setProps(std::shared_ptr<Deck::Props> props) {
 
 void Deck::run(std::function<void(Deck*)> onAfterRender) {
   // TODO(ilija@unfolded.ai): We've got a retain cycle here, revisit
-  this->animationLoop->run([&](wgpu::RenderPassEncoder pass) {
-    this->props()->onBeforeRender(this);
-
-    for (auto const& viewport : this->viewManager->getViewports()) {
-      // Expose the current viewport to layers for project* function
-      this->layerManager->activateViewport(viewport);
-
-      for (auto const& layer : this->layerManager->layers) {
-        // TODO(ilija@unfolded.ai): Pass relevant layer properties to getUniformsFromViewport
-        auto viewportUniforms = getUniformsFromViewport(viewport, this->animationLoop->devicePixelRatio());
-
-        auto uniformArray = std::make_shared<lumagl::garrow::Array>(this->context->device, &viewportUniforms, 1,
-                                                                    wgpu::BufferUsage::Uniform);
-        for (auto const& model : layer->getModels()) {
-          // Viewport uniforms are currently bound to index 0
-          model->setUniforms(uniformArray, 0);
-        }
-
-        layer->draw(pass);
-      }
-    }
-
-    onAfterRender(this);
-    this->props()->onAfterRender(this);
-  });
+  this->animationLoop->run([&](wgpu::RenderPassEncoder pass) { this->_draw(pass, onAfterRender); });
 }
+
+void Deck::draw(wgpu::TextureView textureView, std::function<void(Deck*)> onAfterRender) {
+  // TODO(ilija@unfolded.ai): We've got a retain cycle here, revisit
+  this->animationLoop->frame(textureView, [&](wgpu::RenderPassEncoder pass) { this->_draw(pass, onAfterRender); });
+}
+
+void Deck::stop() { this->animationLoop->stop(); }
 
 // Public API
 // Check if a redraw is needed
@@ -220,6 +210,46 @@ pickObjects(opts) {
 */
 
 // Private Methods
+
+auto Deck::_createAnimationLoop(const std::shared_ptr<Deck::Props>& props) -> std::shared_ptr<lumagl::AnimationLoop> {
+  auto size = lumagl::Size{props->width, props->height};
+  if (props->renderingOptions) {
+    auto options = props->renderingOptions.value();
+    if (options.usesWindow) {
+      return std::make_shared<lumagl::GLFWAnimationLoop>(size, props->id, options.device, options.queue);
+    } else {
+      return std::make_shared<lumagl::AnimationLoop>(options.device, options.queue, size);
+    }
+  } else {
+    return std::make_shared<lumagl::GLFWAnimationLoop>(size, props->id);
+  }
+}
+
+void Deck::_draw(wgpu::RenderPassEncoder pass, std::function<void(Deck*)> onAfterRender) {
+  this->props()->onBeforeRender(this);
+
+  for (auto const& viewport : this->viewManager->getViewports()) {
+    // Expose the current viewport to layers for project* function
+    this->layerManager->activateViewport(viewport);
+
+    for (auto const& layer : this->layerManager->layers) {
+      // TODO(ilija@unfolded.ai): Pass relevant layer properties to getUniformsFromViewport
+      auto viewportUniforms = getUniformsFromViewport(viewport, this->animationLoop->devicePixelRatio());
+
+      this->_viewportUniformsBuffer.SetSubData(0, sizeof(ViewportUniforms), &viewportUniforms);
+      for (auto const& model : layer->getModels()) {
+        // Viewport uniforms are currently bound to index 0
+        model->setUniformBuffer(0, this->_viewportUniformsBuffer);
+      }
+
+      layer->draw(pass);
+    }
+  }
+
+  onAfterRender(this);
+  this->props()->onAfterRender(this);
+}
+
 // Get the most relevant view state: props->viewState, if supplied,
 // shadows internal viewState
 // TODO(ib@unfolded.ai): For backwards compatibility ensure numeric width and height is

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -156,8 +156,6 @@ auto LineLayer::_getModel(wgpu::Device device) -> std::shared_ptr<lumagl::Model>
   auto instancedAttributes = this->attributeManager->update(this->props()->data);
   model->setInstancedAttributes(instancedAttributes);
 
-  model->vertexCount = static_cast<int>(positionData.size());
-
   return model;
 }
 

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -76,7 +76,8 @@ void LineLayer::initializeState() {
   this->attributeManager->add(garrow::ColumnBuilder{width, getWidth});
 
   this->models = {this->_getModel(this->context->device)};
-  this->_layerUniforms = std::make_shared<garrow::Array>(this->context->device);
+  this->_layerUniforms =
+      utils::createBuffer(this->context->device, sizeof(LineLayerUniforms), wgpu::BufferUsage::Uniform);
 }
 
 void LineLayer::updateState(const Layer::ChangeFlags& changeFlags, const Layer::Props* oldProps) {
@@ -90,7 +91,7 @@ void LineLayer::updateState(const Layer::ChangeFlags& changeFlags, const Layer::
   layerUniforms.widthMinPixels = props->widthMinPixels;
   layerUniforms.widthMaxPixels = props->widthMaxPixels;
 
-  this->_layerUniforms->setData(&layerUniforms, 1, wgpu::BufferUsage::Uniform);
+  this->_layerUniforms.SetSubData(0, sizeof(LineLayerUniforms), &layerUniforms);
 
   /*
   super::updateState(props, oldProps, changeFlags);
@@ -114,7 +115,7 @@ void LineLayer::drawState(wgpu::RenderPassEncoder pass) {
 
   for (auto const& model : this->getModels()) {
     // Layer uniforms are currently bound to index 1
-    model->setUniforms(this->_layerUniforms, 1);
+    model->setUniformBuffer(1, this->_layerUniforms);
     model->draw(pass);
   }
 }
@@ -136,7 +137,7 @@ auto LineLayer::_getModel(wgpu::Device device) -> std::shared_ptr<lumagl::Model>
                                      fs,
                                      attributeSchema,
                                      instancedAttributeSchema,
-                                     {{sizeof(ViewportUniforms)}, {sizeof(LineLayerUniforms)}},
+                                     {UniformDescriptor{}, UniformDescriptor{}},
                                      wgpu::PrimitiveTopology::TriangleStrip};
   auto model = std::make_shared<lumagl::Model>(device, modelOptions);
 

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
@@ -58,7 +58,7 @@ class LineLayer : public Layer {
  private:
   auto _getModel(wgpu::Device) -> std::shared_ptr<lumagl::Model>;
 
-  std::shared_ptr<lumagl::garrow::Array> _layerUniforms;
+  wgpu::Buffer _layerUniforms;
 };
 
 class LineLayer::Props : public Layer::Props {

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
@@ -248,7 +248,5 @@ auto ScatterplotLayer::_getModel(wgpu::Device device) -> std::shared_ptr<lumagl:
   auto instancedAttributes = this->attributeManager->update(this->props()->data);
   model->setInstancedAttributes(instancedAttributes);
 
-  model->vertexCount = static_cast<int>(positionData.size());
-
   return model;
 }

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
@@ -57,7 +57,7 @@ class ScatterplotLayer : public Layer {
  private:
   auto _getModel(wgpu::Device device) -> std::shared_ptr<lumagl::Model>;
 
-  std::shared_ptr<lumagl::garrow::Array> _layerUniforms;
+  wgpu::Buffer _layerUniforms;
 };
 
 class ScatterplotLayer::Props : public Layer::Props {

--- a/cpp/modules/luma.gl/CMakeLists.txt
+++ b/cpp/modules/luma.gl/CMakeLists.txt
@@ -69,11 +69,14 @@ set(HEADER_FILE_LIST
     core/src/animation-loop.h
     core/src/glfw-animation-loop.h
     core/src/model.h
+    core/src/blit-model.h
+    core/src/size.h
     )
 set(SOURCE_FILE_LIST
     core/src/animation-loop.cpp
     core/src/glfw-animation-loop.cpp
     core/src/model.cpp
+    core/src/blit-model.cc
     )
 set(TESTS_SOURCE_FILE_LIST
     )

--- a/cpp/modules/luma.gl/core/src/animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/animation-loop.h
@@ -27,48 +27,42 @@
 #include <functional>
 #include <memory>
 
+#include "./size.h"
+
 namespace lumagl {
-
-struct Size {
- public:
-  Size(int width, int height) : width{width}, height{height} {}
-
-  int width;
-  int height;
-};
 
 class AnimationLoop {
  public:
-  explicit AnimationLoop(const Size& size = Size{640, 480});
+  AnimationLoop(wgpu::Device device, wgpu::Queue queue = nullptr, const Size& size = Size{640, 480});
   virtual ~AnimationLoop();
 
   virtual void run(std::function<void(wgpu::RenderPassEncoder)> onRender);
-  virtual void frame(std::function<void(wgpu::RenderPassEncoder)> onRender);
+  virtual void frame(std::function<void(wgpu::RenderPassEncoder)> onRender) {}
+  virtual void frame(wgpu::TextureView textureView, std::function<void(wgpu::RenderPassEncoder)> onRender);
   virtual void stop();
 
   virtual auto shouldQuit() -> bool { return false; }
   virtual void flush() {}
   virtual auto getPreferredSwapChainTextureFormat() -> wgpu::TextureFormat { return wgpu::TextureFormat::Undefined; };
-  virtual auto devicePixelRatio() -> float = 0;
+  virtual auto devicePixelRatio() -> float { return 1.0f; }
+  virtual void setSize(const Size& size);
 
   auto size() -> Size { return this->_size; };
-  void setSize(const Size& size);
 
   bool running{false};
   auto device() -> wgpu::Device { return this->_device; }
+  auto queue() -> wgpu::Queue { return this->_queue; }
 
  protected:
-  void _initialize(const wgpu::BackendType backendType, wgpu::Device device);
-  virtual auto _createDevice(const wgpu::BackendType backendType) -> wgpu::Device = 0;
-  virtual auto _createSwapchain(wgpu::Device device) -> wgpu::SwapChain = 0;
+  // Used by GLFWAnimationLoop as passing a Device to the constructor is not very easy
+  explicit AnimationLoop(const Size& size = Size{640, 480}) : _size{size} {}
+  void _initialize(wgpu::Device device, wgpu::Queue queue);
 
   Size _size;
+  wgpu::Device _device;
 
  private:
-  DawnProcTable _procs;
-  wgpu::Device _device;
   wgpu::Queue _queue;
-  wgpu::SwapChain _swapchain;
 };
 
 }  // namespace lumagl

--- a/cpp/modules/luma.gl/core/src/animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/animation-loop.h
@@ -36,9 +36,9 @@ class AnimationLoop {
   AnimationLoop(wgpu::Device device, wgpu::Queue queue = nullptr, const Size& size = Size{640, 480});
   virtual ~AnimationLoop();
 
+  virtual void draw(std::function<void(wgpu::RenderPassEncoder)> onRender) {}
+  virtual void draw(wgpu::TextureView textureView, std::function<void(wgpu::RenderPassEncoder)> onRender);
   virtual void run(std::function<void(wgpu::RenderPassEncoder)> onRender);
-  virtual void frame(std::function<void(wgpu::RenderPassEncoder)> onRender) {}
-  virtual void frame(wgpu::TextureView textureView, std::function<void(wgpu::RenderPassEncoder)> onRender);
   virtual void stop();
 
   virtual auto shouldQuit() -> bool { return false; }
@@ -47,7 +47,7 @@ class AnimationLoop {
   virtual auto devicePixelRatio() -> float { return 1.0f; }
   virtual void setSize(const Size& size);
 
-  auto size() -> Size { return this->_size; };
+  auto size() const -> Size { return this->_size; };
 
   bool running{false};
   auto device() -> wgpu::Device { return this->_device; }

--- a/cpp/modules/luma.gl/core/src/blit-model.cc
+++ b/cpp/modules/luma.gl/core/src/blit-model.cc
@@ -1,0 +1,94 @@
+// Copyright (c) 2020 Unfolded Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "./blit-model.h"  // NOLINT(build/include)
+
+#include <fmt/core.h>
+
+#include <memory>
+#include <vector>
+
+#include "math.gl/core.h"
+
+using namespace lumagl;
+using namespace mathgl;
+
+namespace {
+
+static auto vs = R"(
+#version 450
+
+layout(location = 0) in vec4 pos;
+
+void main() {
+  gl_Position = pos;
+}
+)";
+
+// Escape curly braces not used in fmt::format by using double braces (https://fmt.dev/dev/syntax.html)
+static auto fs = R"(
+#version 450
+
+layout(set = 0, binding = 0) uniform sampler textureSampler;
+layout(set = 0, binding = 1) uniform texture2D blitTexture;
+
+layout(location = 0) out vec4 fragColor;
+
+void main() {{
+  fragColor = texture(sampler2D(blitTexture, textureSampler), gl_FragCoord.xy / vec2({}, {}));
+}}
+)";
+
+static auto getFragmentShader(const Size& textureSize) -> std::string {
+  return fmt::format(fs, textureSize.width, textureSize.height);
+}
+
+static auto attributeSchema = std::make_shared<garrow::Schema>(
+    std::vector<std::shared_ptr<garrow::Field>>{std::make_shared<garrow::Field>("pos", wgpu::VertexFormat::Float2)});
+
+static auto getOptions(const wgpu::Device& device, const Size& textureSize) -> Model::Options {
+  auto instancedSchema = std::make_shared<garrow::Schema>(std::vector<std::shared_ptr<garrow::Field>>{});
+
+  return Model::Options{vs,
+                        getFragmentShader(textureSize),
+                        attributeSchema,
+                        instancedSchema,
+                        {UniformDescriptor{wgpu::ShaderStage::Fragment, wgpu::BindingType::Sampler},
+                         UniformDescriptor{wgpu::ShaderStage::Fragment, wgpu::BindingType::SampledTexture}},
+                        wgpu::PrimitiveTopology::TriangleStrip};
+}
+
+};  // anonymous namespace
+
+BlitModel::BlitModel(const wgpu::Device& device, const wgpu::TextureView& textureView, const Size& textureSize)
+    : Model{device, getOptions(device, textureSize)} {
+  auto samplerDesc = utils::getDefaultSamplerDescriptor();
+  auto sampler = device.CreateSampler(&samplerDesc);
+
+  std::vector<std::shared_ptr<garrow::Array>> attribureArrays{std::make_shared<garrow::Array>(
+      device, std::vector<Vector2<float>>{{-1, -1}, {1, -1}, {-1, 1}, {1, 1}}, wgpu::BufferUsage::Vertex)};
+
+  auto attributes = std::make_shared<garrow::Table>(attributeSchema, attribureArrays);
+
+  this->setAttributes(attributes);
+  this->vertexCount = static_cast<int>(attributes->num_rows());
+  this->setUniformSampler(0, sampler);
+  this->setUniformTexture(1, textureView);
+}

--- a/cpp/modules/luma.gl/core/src/blit-model.h
+++ b/cpp/modules/luma.gl/core/src/blit-model.h
@@ -18,13 +18,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef LUMAGL_CORE_H
-#define LUMAGL_CORE_H
+#ifndef LUMAGL_CORE_BLIT_MODEL_H
+#define LUMAGL_CORE_BLIT_MODEL_H
 
-#include "./core/src/animation-loop.h"
-#include "./core/src/blit-model.h"
-#include "./core/src/glfw-animation-loop.h"
-#include "./core/src/model.h"
-#include "./core/src/size.h"
+#include "./model.h"
+#include "./size.h"
 
-#endif  // LUMAGL_CORE_CORE_H
+namespace lumagl {
+
+/// Model subclass that provides an easy way to render draw a given texture.
+class BlitModel : public Model {
+ public:
+  BlitModel(const wgpu::Device& device, const wgpu::TextureView& textureView, const Size& textureSize);
+};
+
+}  // namespace lumagl
+
+#endif  // LUMAGL_CORE_BLIT_MODEL_H

--- a/cpp/modules/luma.gl/core/src/blit-model.h
+++ b/cpp/modules/luma.gl/core/src/blit-model.h
@@ -30,6 +30,11 @@ namespace lumagl {
 class BlitModel : public Model {
  public:
   BlitModel(const wgpu::Device& device, const wgpu::TextureView& textureView, const Size& textureSize);
+
+  void setTextureSize(const Size& textureSize);
+
+ private:
+  auto _uniformBufferFromSize(const Size& size) -> wgpu::Buffer;
 };
 
 }  // namespace lumagl

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
@@ -60,7 +60,7 @@ GLFWAnimationLoop::GLFWAnimationLoop(const Size& size, const std::string& window
 
   this->_binding = CreateBinding(backendType, this->_window, _device.Get());
   if (!this->_binding) {
-    throw new std::runtime_error("Failed to create binding");
+    throw new std::runtime_error("Failed to initialize GLFWAnimationLoop, no backends enable for luma.gl");
   }
 
   this->_swapchain = this->_createSwapchain(_device);
@@ -74,14 +74,14 @@ GLFWAnimationLoop::~GLFWAnimationLoop() {
   // TODO(ilija@unfolded.ai): Additional cleanup?
 }
 
-void GLFWAnimationLoop::frame(std::function<void(wgpu::RenderPassEncoder)> onRender) {
+void GLFWAnimationLoop::draw(std::function<void(wgpu::RenderPassEncoder)> onRender) {
   // Break the run loop if esc is pressed
   if (glfwGetKey(this->_window, GLFW_KEY_ESCAPE) == GLFW_PRESS) {
     glfwSetWindowShouldClose(this->_window, true);
   }
 
   wgpu::TextureView backbufferView = this->_swapchain.GetCurrentTextureView();
-  super::frame(backbufferView, onRender);
+  super::draw(backbufferView, onRender);
   this->_swapchain.Present();
 }
 

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
@@ -40,22 +40,31 @@
 using namespace lumagl;
 using namespace lumagl::utils;
 
-GLFWAnimationLoop::GLFWAnimationLoop(const Size& size, const wgpu::BackendType backendType, wgpu::Device device)
+GLFWAnimationLoop::GLFWAnimationLoop(const Size& size, const std::string& windowTitle, const wgpu::Device& device,
+                                     const wgpu::Queue& queue, const wgpu::BackendType backendType)
     : AnimationLoop{size} {
-  this->_window = this->_initializeGLFW(backendType);
+  this->_window = this->_initializeGLFW(backendType, windowTitle);
 
-  // Create a device if none was provided
-  auto _device = device;
-  if (device == nullptr) {
-    _device = this->_createDevice(backendType);
+  // NOTE: This **must** be done before any wgpu API calls as otherwise functions will be undefined
+  // TODO(ilija@unfolded.ai): Set this globally elsewhere
+  static bool procTableInitialized = false;
+  DawnProcTable procs = dawn_native::GetProcs();
+  if (!procTableInitialized) {
+    dawnProcSetProcs(&procs);
+    procTableInitialized = true;
   }
 
+  // Create a device if none was provided
+  auto _device = device ? device : this->_createDevice(backendType);
+  auto _queue = queue ? queue : _device.CreateQueue();
+
   this->_binding = CreateBinding(backendType, this->_window, _device.Get());
-  if (this->_binding == nullptr) {
+  if (!this->_binding) {
     throw new std::runtime_error("Failed to create binding");
   }
 
-  this->_initialize(backendType, _device);
+  this->_swapchain = this->_createSwapchain(_device);
+  this->_initialize(_device, _queue);
 }
 
 GLFWAnimationLoop::~GLFWAnimationLoop() {
@@ -71,7 +80,9 @@ void GLFWAnimationLoop::frame(std::function<void(wgpu::RenderPassEncoder)> onRen
     glfwSetWindowShouldClose(this->_window, true);
   }
 
-  AnimationLoop::frame(onRender);
+  wgpu::TextureView backbufferView = this->_swapchain.GetCurrentTextureView();
+  super::frame(backbufferView, onRender);
+  this->_swapchain.Present();
 }
 
 bool GLFWAnimationLoop::shouldQuit() { return glfwWindowShouldClose(this->_window); }
@@ -93,6 +104,15 @@ auto GLFWAnimationLoop::devicePixelRatio() -> float {
   }
 
   return xscale;
+}
+
+void GLFWAnimationLoop::setSize(const Size& size) {
+  bool sizeChanged = size.width != this->_size.width || size.height != this->_size.height;
+  if (sizeChanged) {
+    this->_swapchain = this->_createSwapchain(this->_device);
+  }
+
+  super::setSize(size);
 }
 
 auto GLFWAnimationLoop::_createDevice(const wgpu::BackendType backendType) -> wgpu::Device {
@@ -126,7 +146,8 @@ auto GLFWAnimationLoop::_createSwapchain(wgpu::Device device) -> wgpu::SwapChain
   return swapchain;
 }
 
-auto GLFWAnimationLoop::_initializeGLFW(const wgpu::BackendType backendType) -> GLFWwindow* {
+auto GLFWAnimationLoop::_initializeGLFW(const wgpu::BackendType backendType, const std::string& windowTitle)
+    -> GLFWwindow* {
   // Set up an error logging callback
   glfwSetErrorCallback(
       [](int code, const char* message) { probegl::ErrorLog() << "GLFW error: " << code << " - " << message; });
@@ -151,7 +172,7 @@ auto GLFWAnimationLoop::_initializeGLFW(const wgpu::BackendType backendType) -> 
       glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
   }
 
-  auto window = glfwCreateWindow(this->_size.width, this->_size.height, "deck.gl window", nullptr, nullptr);
+  auto window = glfwCreateWindow(this->_size.width, this->_size.height, windowTitle.c_str(), nullptr, nullptr);
   if (!window) {
     throw new std::runtime_error("Failed to create GLFW window");
   }

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
@@ -22,6 +22,7 @@
 #define LUMAGL_CORE_GLFW_ANIMATION_LOOP_H
 
 #include <memory>
+#include <string>
 
 #include "./animation-loop.h"
 #include "luma.gl/webgpu/src/backends/backend-binding.h"
@@ -33,9 +34,11 @@ namespace lumagl {
 
 class GLFWAnimationLoop : public AnimationLoop {
  public:
-  GLFWAnimationLoop(const Size& size = Size{640, 480},
-                    const wgpu::BackendType backendType = utils::getDefaultWebGPUBackendType(),
-                    wgpu::Device device = nullptr);
+  using super = AnimationLoop;
+
+  GLFWAnimationLoop(const Size& size = Size{640, 480}, const std::string& windowTitle = "deck.gl",
+                    const wgpu::Device& device = nullptr, const wgpu::Queue& queue = nullptr,
+                    const wgpu::BackendType backendType = utils::getDefaultWebGPUBackendType());
   ~GLFWAnimationLoop();
 
   void frame(std::function<void(wgpu::RenderPassEncoder)> onRender) override;
@@ -44,13 +47,12 @@ class GLFWAnimationLoop : public AnimationLoop {
   void flush() override;
   auto getPreferredSwapChainTextureFormat() -> wgpu::TextureFormat override;
   auto devicePixelRatio() -> float override;
-
- protected:
-  auto _createDevice(const wgpu::BackendType backendType) -> wgpu::Device override;
-  auto _createSwapchain(wgpu::Device device) -> wgpu::SwapChain override;
+  void setSize(const Size& size) override;
 
  private:
-  auto _initializeGLFW(const wgpu::BackendType) -> GLFWwindow*;
+  auto _createDevice(const wgpu::BackendType backendType) -> wgpu::Device;
+  auto _createSwapchain(wgpu::Device device) -> wgpu::SwapChain;
+  auto _initializeGLFW(const wgpu::BackendType backendType, const std::string& windowTitle) -> GLFWwindow*;
 
   /// \brief Instance used for adapter discovery and device creation. It has to be kept around as Dawn objects'
   /// lifecycle seems to depend on it.
@@ -58,6 +60,8 @@ class GLFWAnimationLoop : public AnimationLoop {
   /// for this instance.
   std::unique_ptr<dawn_native::Instance> _instance{nullptr};
   utils::BackendBinding* _binding{nullptr};
+  wgpu::SwapChain _swapchain;
+
   GLFWwindow* _window{nullptr};
 };
 

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.h
@@ -36,12 +36,12 @@ class GLFWAnimationLoop : public AnimationLoop {
  public:
   using super = AnimationLoop;
 
-  GLFWAnimationLoop(const Size& size = Size{640, 480}, const std::string& windowTitle = "deck.gl",
+  GLFWAnimationLoop(const Size& size = Size{640, 480}, const std::string& windowTitle = "luma.gl",
                     const wgpu::Device& device = nullptr, const wgpu::Queue& queue = nullptr,
                     const wgpu::BackendType backendType = utils::getDefaultWebGPUBackendType());
   ~GLFWAnimationLoop();
 
-  void frame(std::function<void(wgpu::RenderPassEncoder)> onRender) override;
+  void draw(std::function<void(wgpu::RenderPassEncoder)> onRender) override;
 
   auto shouldQuit() -> bool override;
   void flush() override;

--- a/cpp/modules/luma.gl/core/src/model.cpp
+++ b/cpp/modules/luma.gl/core/src/model.cpp
@@ -94,10 +94,11 @@ void Model::draw(wgpu::RenderPassEncoder pass) {
   // The last two arguments are used for specifying dynamic offsets, which is not something we support right now
   pass.SetBindGroup(0, this->bindGroup, 0, nullptr);
 
+  auto vertexCount = static_cast<uint32_t>(this->_attributeTable->num_rows());
   // Make sure at least one instance is being drawn in case no instanced attributes are present
   uint32_t minimumInstances = 1;
   auto instanceCount = std::max(static_cast<uint32_t>(this->_instancedAttributeTable->num_rows()), minimumInstances);
-  pass.Draw(this->vertexCount, instanceCount, 0, 0);
+  pass.Draw(vertexCount, instanceCount, 0, 0);
 }
 
 void Model::_initializeVertexState(utils::ComboVertexStateDescriptor* descriptor,

--- a/cpp/modules/luma.gl/core/src/model.cpp
+++ b/cpp/modules/luma.gl/core/src/model.cpp
@@ -51,8 +51,7 @@ Model::Model(wgpu::Device device, const Model::Options& options) {
   this->_initializeVertexState(&descriptor.cVertexState, options.attributeSchema, options.instancedAttributeSchema);
 
   // Initialize uniform cache
-  this->_bindings = std::vector<std::shared_ptr<BindingInitializationHelper>>{options.uniforms.size()};
-  this->_uniforms = std::vector<std::shared_ptr<garrow::Array>>{options.uniforms.size()};
+  this->_bindings = std::vector<std::optional<BindingInitializationHelper>>{options.uniforms.size()};
 
   this->uniformBindGroupLayout = this->_createBindGroupLayout(device, options.uniforms);
   descriptor.layout = makeBasicPipelineLayout(device, &this->uniformBindGroupLayout);
@@ -77,36 +76,16 @@ void Model::setInstancedAttributes(const std::shared_ptr<garrow::Table>& attribu
   this->_instancedAttributeTable = attributes;
 }
 
-void Model::setUniforms(const std::vector<std::shared_ptr<garrow::Array>>& uniforms) {
-  std::vector<std::shared_ptr<BindingInitializationHelper>> bindings;
-  for (uint32_t i = 0; i < uniforms.size(); i++) {
-    bindings.push_back(std::make_shared<BindingInitializationHelper>(i, uniforms[i]->buffer(), 0,
-                                                                     this->_uniformDescriptors[i].elementSize));
-  }
-
-  // Cache the bindings so they can be updated individually
-  this->_bindings = bindings;
-  this->_uniforms = uniforms;
-
-  // Update the bind group
-  this->bindGroup = utils::makeBindGroup(this->_device, this->uniformBindGroupLayout, bindings);
+void Model::setUniformBuffer(uint32_t binding, const wgpu::Buffer& buffer, uint64_t offset, uint64_t size) {
+  this->_setBinding(binding, BindingInitializationHelper{binding, buffer, offset, size});
 }
 
-void Model::setUniforms(const std::shared_ptr<garrow::Array>& uniforms, uint32_t index) {
-  auto binding = std::make_shared<BindingInitializationHelper>(index, uniforms->buffer(), 0,
-                                                               this->_uniformDescriptors[index].elementSize);
-  this->_bindings[index] = binding;
-  this->_uniforms[index] = uniforms;
+void Model::setUniformTexture(uint32_t binding, const wgpu::TextureView& textureView) {
+  this->_setBinding(binding, BindingInitializationHelper{binding, textureView});
+}
 
-  // Make sure all uniforms are set before trying to create a bind group
-  for (auto const& binding : this->_bindings) {
-    if (binding == nullptr) {
-      return;
-    }
-  }
-
-  // Update the bind group
-  this->bindGroup = utils::makeBindGroup(this->_device, this->uniformBindGroupLayout, this->_bindings);
+void Model::setUniformSampler(uint32_t binding, const wgpu::Sampler& sampler) {
+  this->_setBinding(binding, BindingInitializationHelper{binding, sampler});
 }
 
 void Model::draw(wgpu::RenderPassEncoder pass) {
@@ -157,12 +136,29 @@ auto Model::_createBindGroupLayout(wgpu::Device device, const std::vector<Unifor
     -> wgpu::BindGroupLayout {
   std::vector<wgpu::BindGroupLayoutBinding> bindings;
   for (uint32_t i = 0; i < uniforms.size(); i++) {
-    auto binding = wgpu::BindGroupLayoutBinding{i, uniforms[i].shaderStage, wgpu::BindingType::UniformBuffer,
-                                                uniforms[i].isDynamic};
+    auto binding =
+        wgpu::BindGroupLayoutBinding{i, uniforms[i].shaderStage, uniforms[i].bindingType, uniforms[i].isDynamic};
     bindings.push_back(binding);
   }
 
   return utils::makeBindGroupLayout(device, bindings);
+}
+
+void Model::_setBinding(uint32_t binding, const BindingInitializationHelper& initHelper) {
+  this->_bindings[binding] = initHelper;
+
+  // Make sure all uniforms are set before trying to create a bind group
+  std::vector<BindingInitializationHelper> bindings;
+  for (auto const& binding : this->_bindings) {
+    if (binding) {
+      bindings.push_back(binding.value());
+    } else {
+      return;
+    }
+  }
+
+  // Update the bind group
+  this->bindGroup = utils::makeBindGroup(this->_device, this->uniformBindGroupLayout, bindings);
 }
 
 void Model::_setVertexBuffers(wgpu::RenderPassEncoder pass) {

--- a/cpp/modules/luma.gl/core/src/model.h
+++ b/cpp/modules/luma.gl/core/src/model.h
@@ -68,8 +68,6 @@ class Model {
 
   auto device() -> wgpu::Device { return this->_device; }
 
-  int vertexCount;
-
   /// \brief Rendering pipeline.
   wgpu::RenderPipeline pipeline;
   /// \brief Layout of the bind group.

--- a/cpp/modules/luma.gl/core/src/size.h
+++ b/cpp/modules/luma.gl/core/src/size.h
@@ -18,13 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef LUMAGL_CORE_H
-#define LUMAGL_CORE_H
+#ifndef LUMAGL_CORE_SIZE_H
+#define LUMAGL_CORE_SIZE_H
 
-#include "./core/src/animation-loop.h"
-#include "./core/src/blit-model.h"
-#include "./core/src/glfw-animation-loop.h"
-#include "./core/src/model.h"
-#include "./core/src/size.h"
+namespace lumagl {
 
-#endif  // LUMAGL_CORE_CORE_H
+struct Size {
+ public:
+  Size(int width, int height) : width{width}, height{height} {}
+
+  template <typename T>
+  auto operator*(const T& value) -> Size {
+    return Size{this->width * static_cast<int>(value), this->height * static_cast<int>(value)};
+  }
+
+  int width;
+  int height;
+};
+
+}  // namespace lumagl
+
+#endif  // LUMAGL_CORE_SIZE_H

--- a/cpp/modules/luma.gl/webgpu/src/webgpu-helpers.cpp
+++ b/cpp/modules/luma.gl/webgpu/src/webgpu-helpers.cpp
@@ -37,14 +37,19 @@ using namespace lumagl::utils;
 namespace lumagl {
 namespace utils {
 
-auto createBufferFromData(const wgpu::Device& device, const void* data, uint64_t size, wgpu::BufferUsage usage)
-    -> wgpu::Buffer {
+auto createBuffer(const wgpu::Device& device, uint64_t size, wgpu::BufferUsage usage) -> wgpu::Buffer {
   wgpu::BufferDescriptor descriptor;
   descriptor.size = size;
   descriptor.usage = usage | wgpu::BufferUsage::CopyDst;
 
-  wgpu::Buffer buffer = device.CreateBuffer(&descriptor);
+  return device.CreateBuffer(&descriptor);
+}
+
+auto createBufferFromData(const wgpu::Device& device, const void* data, uint64_t size, wgpu::BufferUsage usage)
+    -> wgpu::Buffer {
+  auto buffer = createBuffer(device, size, usage);
   buffer.SetSubData(0, size, data);
+
   return buffer;
 }
 

--- a/cpp/modules/luma.gl/webgpu/src/webgpu-helpers.h
+++ b/cpp/modules/luma.gl/webgpu/src/webgpu-helpers.h
@@ -38,6 +38,8 @@ namespace utils {
 
 enum Expectation { Success, Failure };
 
+auto createBuffer(const wgpu::Device& device, uint64_t size, wgpu::BufferUsage usage) -> wgpu::Buffer;
+
 auto createBufferFromData(const wgpu::Device& device, const void* data, uint64_t size, wgpu::BufferUsage usage)
     -> wgpu::Buffer;
 

--- a/deck.gl-native.xcodeproj/project.pbxproj
+++ b/deck.gl-native.xcodeproj/project.pbxproj
@@ -8,6 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		CD1CCD8E24446CEB00C96D72 /* array.cc in Sources */ = {isa = PBXBuildFile; fileRef = CD1CCD8B24446C6600C96D72 /* array.cc */; };
+		CD235261246256F400E3F139 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF2D242E2072003F3B96 /* Cocoa.framework */; };
+		CD23526224627CBE00E3F139 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF1E242E1EB4003F3B96 /* Metal.framework */; };
+		CD23526324627CC300E3F139 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF3C242E2207003F3B96 /* QuartzCore.framework */; };
+		CD23526424627CC700E3F139 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF2F242E2076003F3B96 /* IOKit.framework */; };
+		CD23526524627CD000E3F139 /* libdeck.gl-native.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD903E9E241A0DB50047F954 /* libdeck.gl-native.a */; };
+		CD23526824627CD500E3F139 /* libdawn_native.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CDE57860243C70F5000D8EC6 /* libdawn_native.dylib */; };
+		CD23526924627CD500E3F139 /* libdawn_native.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = CDE57860243C70F5000D8EC6 /* libdawn_native.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		CD23526D24627CDF00E3F139 /* libdawn_proc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CDE5786A243C70F6000D8EC6 /* libdawn_proc.dylib */; };
+		CD23526E24627CDF00E3F139 /* libdawn_proc.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = CDE5786A243C70F6000D8EC6 /* libdawn_proc.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		CD23526F24627F7800E3F139 /* manhattan.ndjson in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD58569D24612E200076227F /* manhattan.ndjson */; };
 		CD33DF1F242E1EB4003F3B96 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF1E242E1EB4003F3B96 /* Metal.framework */; };
 		CD33DF20242E1EBC003F3B96 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF1E242E1EB4003F3B96 /* Metal.framework */; };
 		CD33DF2E242E2073003F3B96 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF2D242E2072003F3B96 /* Cocoa.framework */; };
@@ -21,6 +31,9 @@
 		CD452A51244852DE00DD44A5 /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = CD452A4E244852DE00DD44A5 /* field.h */; };
 		CD452A552448565000DD44A5 /* schema.cc in Sources */ = {isa = PBXBuildFile; fileRef = CD452A522448565000DD44A5 /* schema.cc */; };
 		CD452A562448565000DD44A5 /* schema.h in Headers */ = {isa = PBXBuildFile; fileRef = CD452A532448565000DD44A5 /* schema.h */; };
+		CD57340F24640A3300D22A70 /* blit-model.cc in Sources */ = {isa = PBXBuildFile; fileRef = CD57340D24640A3300D22A70 /* blit-model.cc */; };
+		CD57341024640A3300D22A70 /* blit-model.h in Headers */ = {isa = PBXBuildFile; fileRef = CD57340E24640A3300D22A70 /* blit-model.h */; };
+		CD57341224640E6200D22A70 /* size.h in Headers */ = {isa = PBXBuildFile; fileRef = CD57341124640E6200D22A70 /* size.h */; };
 		CD5856C0246131740076227F /* libdeck.gl-native.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD903E9E241A0DB50047F954 /* libdeck.gl-native.a */; };
 		CD5856C3246132240076227F /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF1E242E1EB4003F3B96 /* Metal.framework */; };
 		CD5856C4246132280076227F /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF2F242E2076003F3B96 /* IOKit.framework */; };
@@ -74,6 +87,7 @@
 		CDCD8F2B24614F60009604C5 /* libdawn_proc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CDE5786A243C70F6000D8EC6 /* libdawn_proc.dylib */; };
 		CDCD8F2C24614F73009604C5 /* libdawn_native.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = CDE57860243C70F5000D8EC6 /* libdawn_native.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		CDCD8F2E24614F74009604C5 /* libdawn_proc.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = CDE5786A243C70F6000D8EC6 /* libdawn_proc.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		CDCD8F3D2461841D009604C5 /* texture-render.cc in Sources */ = {isa = PBXBuildFile; fileRef = CDCD8F2F246183FC009604C5 /* texture-render.cc */; };
 		CDE55C6A243C6A11000D8EC6 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDE53EA4243C69FB000D8EC6 /* main.cpp */; };
 		CDE57747243C6A1E000D8EC6 /* core.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE55B2B243C6A10000D8EC6 /* core.h */; };
 		CDE57748243C6A1E000D8EC6 /* timer-test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDE55B2F243C6A10000D8EC6 /* timer-test.cpp */; };
@@ -210,6 +224,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		CD23526624627CD000E3F139 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CD759CDF2417625E0001C15C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CD903E9D241A0DB50047F954;
+			remoteInfo = "deck.gl-native";
+		};
 		CD5856BE246131280076227F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CD759CDF2417625E0001C15C /* Project object */;
@@ -241,6 +262,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		CD23526C24627CD500E3F139 /* Embed Libraries */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				CD23526E24627CDF00E3F139 /* libdawn_proc.dylib in Embed Libraries */,
+				CD23526924627CD500E3F139 /* libdawn_native.dylib in Embed Libraries */,
+			);
+			name = "Embed Libraries";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CD48E80E24178A1E00D3C13C /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -319,6 +352,16 @@
 			name = "Embed Libraries";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CDCD8F3424618413009604C5 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 12;
+			dstPath = data;
+			dstSubfolderSpec = 16;
+			files = (
+				CD23526F24627F7800E3F139 /* manhattan.ndjson in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CDE53E99243C69A4000D8EC6 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 12;
@@ -371,6 +414,9 @@
 		CD452A532448565000DD44A5 /* schema.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = schema.h; sourceTree = "<group>"; };
 		CD48E81024178A1E00D3C13C /* deck.gl-native-tests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "deck.gl-native-tests"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD517429243DC4A50051AB3F /* libshaderc_spvc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libshaderc_spvc.dylib; path = "cpp/deps/x64-osx/lib/libshaderc_spvc.dylib"; sourceTree = "<group>"; };
+		CD57340D24640A3300D22A70 /* blit-model.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "blit-model.cc"; sourceTree = "<group>"; };
+		CD57340E24640A3300D22A70 /* blit-model.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "blit-model.h"; sourceTree = "<group>"; };
+		CD57341124640E6200D22A70 /* size.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = size.h; sourceTree = "<group>"; };
 		CD58569D24612E200076227F /* manhattan.ndjson */ = {isa = PBXFileReference; lastKnownFileType = text; path = manhattan.ndjson; sourceTree = "<group>"; };
 		CD5856D9246135540076227F /* flight-paths */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "flight-paths"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD5856F52461364B0076227F /* manhattan-population */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "manhattan-population"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -394,6 +440,8 @@
 		CDC8E16C244D5B5B002A7E60 /* webgpu-utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "webgpu-utils.h"; sourceTree = "<group>"; };
 		CDC8E170244D6420002A7E60 /* key-value-metadata.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "key-value-metadata.cc"; sourceTree = "<group>"; };
 		CDC8E171244D6420002A7E60 /* key-value-metadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "key-value-metadata.h"; sourceTree = "<group>"; };
+		CDCD8F2F246183FC009604C5 /* texture-render.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "texture-render.cc"; sourceTree = "<group>"; };
+		CDCD8F3624618413009604C5 /* texture-render */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "texture-render"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDE53E9B243C69A4000D8EC6 /* animometer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = animometer; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDE53EA4243C69FB000D8EC6 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		CDE53EA7243C69FB000D8EC6 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
@@ -722,6 +770,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CDCD8F3324618413009604C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD23526224627CBE00E3F139 /* Metal.framework in Frameworks */,
+				CD235261246256F400E3F139 /* Cocoa.framework in Frameworks */,
+				CD23526524627CD000E3F139 /* libdeck.gl-native.a in Frameworks */,
+				CD23526824627CD500E3F139 /* libdawn_native.dylib in Frameworks */,
+				CD23526324627CC300E3F139 /* QuartzCore.framework in Frameworks */,
+				CD23526424627CC700E3F139 /* IOKit.framework in Frameworks */,
+				CD23526D24627CDF00E3F139 /* libdawn_proc.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CDE53E98243C69A4000D8EC6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -774,6 +836,7 @@
 				CDE53E9B243C69A4000D8EC6 /* animometer */,
 				CD5856D9246135540076227F /* flight-paths */,
 				CD5856F52461364B0076227F /* manhattan-population */,
+				CDCD8F3624618413009604C5 /* texture-render */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -963,6 +1026,7 @@
 				CDE53EDC243C69FC000D8EC6 /* stdinout.cpp */,
 				CDE74992244EF71A00FB84CC /* flight-paths.cc */,
 				CD9BE17E246061F00019835B /* manhattan-population.cc */,
+				CDCD8F2F246183FC009604C5 /* texture-render.cc */,
 			);
 			path = deck.gl;
 			sourceTree = "<group>";
@@ -1061,10 +1125,13 @@
 			children = (
 				CDE55B4A243C6A10000D8EC6 /* model.h */,
 				CDE55B4B243C6A10000D8EC6 /* model.cpp */,
+				CD57340E24640A3300D22A70 /* blit-model.h */,
+				CD57340D24640A3300D22A70 /* blit-model.cc */,
 				CDE55B4D243C6A10000D8EC6 /* animation-loop.h */,
 				CDE55B45243C6A10000D8EC6 /* animation-loop.cpp */,
 				CDE55B46243C6A10000D8EC6 /* glfw-animation-loop.h */,
 				CDE55B44243C6A10000D8EC6 /* glfw-animation-loop.cpp */,
+				CD57341124640E6200D22A70 /* size.h */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -1876,6 +1943,7 @@
 				CDE577F0243C6A1F000D8EC6 /* deck.h in Headers */,
 				CDE577B4243C6A1F000D8EC6 /* web-mercator.h in Headers */,
 				CDE57855243C6A1F000D8EC6 /* json.h in Headers */,
+				CD57341224640E6200D22A70 /* size.h in Headers */,
 				CDE5785A243C6A1F000D8EC6 /* csv-loader.h in Headers */,
 				CDE5774E243C6A1F000D8EC6 /* compiler.h in Headers */,
 				CD452A51244852DE00DD44A5 /* field.h in Headers */,
@@ -1918,6 +1986,7 @@
 				CDE57845243C6A1F000D8EC6 /* json.h in Headers */,
 				CDE5780D243C6A1F000D8EC6 /* view-state.h in Headers */,
 				CDE57846243C6A1F000D8EC6 /* json-object.h in Headers */,
+				CD57341024640A3300D22A70 /* blit-model.h in Headers */,
 				CDE577EB243C6A1F000D8EC6 /* viewport.h in Headers */,
 				CDE577A9243C6A1F000D8EC6 /* sample-viewports.h in Headers */,
 				CDE57807243C6A1F000D8EC6 /* view-manager.h in Headers */,
@@ -2032,6 +2101,25 @@
 			productReference = CD903E9E241A0DB50047F954 /* libdeck.gl-native.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		CDCD8F3524618413009604C5 /* texture-render */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CDCD8F3A24618413009604C5 /* Build configuration list for PBXNativeTarget "texture-render" */;
+			buildPhases = (
+				CDCD8F3224618413009604C5 /* Sources */,
+				CDCD8F3324618413009604C5 /* Frameworks */,
+				CDCD8F3424618413009604C5 /* CopyFiles */,
+				CD23526C24627CD500E3F139 /* Embed Libraries */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CD23526724627CD000E3F139 /* PBXTargetDependency */,
+			);
+			name = "texture-render";
+			productName = "texture-render";
+			productReference = CDCD8F3624618413009604C5 /* texture-render */;
+			productType = "com.apple.product-type.tool";
+		};
 		CDE53E9A243C69A4000D8EC6 /* animometer */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CDE53E9F243C69A4000D8EC6 /* Build configuration list for PBXNativeTarget "animometer" */;
@@ -2072,6 +2160,9 @@
 					CD903E9D241A0DB50047F954 = {
 						CreatedOnToolsVersion = 11.3.1;
 					};
+					CDCD8F3524618413009604C5 = {
+						CreatedOnToolsVersion = 11.4.1;
+					};
 					CDE53E9A243C69A4000D8EC6 = {
 						CreatedOnToolsVersion = 11.3.1;
 					};
@@ -2099,6 +2190,7 @@
 				CDE53E9A243C69A4000D8EC6 /* animometer */,
 				CD5856D8246135540076227F /* flight-paths */,
 				CD5856F42461364B0076227F /* manhattan-population */,
+				CDCD8F3524618413009604C5 /* texture-render */,
 			);
 		};
 /* End PBXProject section */
@@ -2193,6 +2285,7 @@
 				CDE5778E243C6A1F000D8EC6 /* backend-binding.cpp in Sources */,
 				CDE577A0243C6A1F000D8EC6 /* combo-render-pipeline-descriptor.cpp in Sources */,
 				CDE577A7243C6A1F000D8EC6 /* web-mercator-utils-test.cpp in Sources */,
+				CD57340F24640A3300D22A70 /* blit-model.cc in Sources */,
 				CDE577FC243C6A1F000D8EC6 /* deck.cpp in Sources */,
 				CDE57781243C6A1F000D8EC6 /* webgpu-helpers.cpp in Sources */,
 				CD452A552448565000DD44A5 /* schema.cc in Sources */,
@@ -2226,6 +2319,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CDCD8F3224618413009604C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDCD8F3D2461841D009604C5 /* texture-render.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CDE53E97243C69A4000D8EC6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2237,6 +2338,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		CD23526724627CD000E3F139 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CD903E9D241A0DB50047F954 /* deck.gl-native */;
+			targetProxy = CD23526624627CD000E3F139 /* PBXContainerItemProxy */;
+		};
 		CD5856BF246131280076227F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = CD903E9D241A0DB50047F954 /* deck.gl-native */;
@@ -2700,6 +2806,71 @@
 			};
 			name = Release;
 		};
+		CDCD8F3B24618413009604C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/cpp/deps/x64-osx/lib",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		CDCD8F3C24618413009604C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/cpp/deps/x64-osx/lib",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		CDE53EA0243C69A4000D8EC6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2962,6 +3133,15 @@
 			buildConfigurations = (
 				CD903EA0241A0DB50047F954 /* Debug */,
 				CD903EA1241A0DB50047F954 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CDCD8F3A24618413009604C5 /* Build configuration list for PBXNativeTarget "texture-render" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CDCD8F3B24618413009604C5 /* Debug */,
+				CDCD8F3C24618413009604C5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/deck.gl-native.xcodeproj/xcshareddata/xcschemes/texture-render.xcscheme
+++ b/deck.gl-native.xcodeproj/xcshareddata/xcschemes/texture-render.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDCD8F3524618413009604C5"
+               BuildableName = "texture-render"
+               BlueprintName = "texture-render"
+               ReferencedContainer = "container:deck.gl-native.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDCD8F3524618413009604C5"
+            BuildableName = "texture-render"
+            BlueprintName = "texture-render"
+            ReferencedContainer = "container:deck.gl-native.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDCD8F3524618413009604C5"
+            BuildableName = "texture-render"
+            BlueprintName = "texture-render"
+            ReferencedContainer = "container:deck.gl-native.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
- Added optional `renderingOptions` to `Deck::Props` which allows the user to pass their own `Device`, `Queue` and toggle between windowed and window-less Decks
- Added `texture-render` example that demonstrates the new API usage, as well as drawing the resulting texture to the screen
- Added `BlitModel` that contains all the boilerplate necessary to draw a texture to clipspace

2 potential improvements:
- `setUniforms` no longer accepts a `garrow::Array` (which as discussed earlier was awkward to begin with), as the example needed support for binding texture and sampler as uniforms. The API for binding a uniform buffer now takes a raw `wgpu::Buffer`, perhaps we want to have a wrapper around it that's not a `garrow::Array`
- I tinkered with reusing Decks declared in other examples, which would bring the new example down to only a few lines of code. We'd need to pass quite a few parameters, and I wasn't sure about the idea in general. Thoughts?