### PR TITLE
Addressed #136 comments

### DIFF
--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cpp
@@ -112,14 +112,15 @@ auto SolidPolygonLayer::getPickingInfo(params) {
 }
 */
 
-void SolidPolygonLayer::updateStateSPL(const Layer::ChangeFlags& changeFlags,
-                                       const SolidPolygonLayer::Props* oldProps) {
+void SolidPolygonLayer::updateState(const Layer::ChangeFlags& changeFlags, const Layer::Props* oldProps) {
+  super::updateState(changeFlags, oldProps);
   updateGeometry(changeFlags, oldProps);
 
   auto props = std::dynamic_pointer_cast<SolidPolygonLayer::Props>(this->props());
+  const auto oldPropsSPL = dynamic_cast<const SolidPolygonLayer::Props*>(const_cast<Layer::Props*>(oldProps));
 
-  bool regenerateModels =
-      (changeFlags.extensionsChanged || (props->filled != oldProps->filled) || (props->extruded != oldProps->extruded));
+  bool regenerateModels = (changeFlags.extensionsChanged || (props->filled != oldPropsSPL->filled) ||
+                           (props->extruded != oldPropsSPL->extruded));
 
   SolidPolygonLayerUniforms uniforms;
   uniforms.elevationScale = props->elevationScale;

--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.h
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.h
@@ -46,7 +46,7 @@ class SolidPolygonLayer : public Layer {
  protected:
   void initializeState() override;
   // auto getPickingInfo() override;
-  void updateStateSPL(const ChangeFlags&, const SolidPolygonLayer::Props* oldProps);
+  void updateState(const ChangeFlags&, const Layer::Props* oldProps) override;
   void updateGeometry(const ChangeFlags&, const Layer::Props* oldProps);
   void finalizeState() override;
   void drawState(wgpu::RenderPassEncoder pass) override;


### PR DESCRIPTION
Reverted updateState in solid-polygon-layer.h/cpp back to its original implementation, overriding that set in the `Layer` parent class. Casted oldProps from `Layer::Props` to `SolidPolygonLayer::Props` within the method.