### PR TITLE
Added install step for lib and example targets. Initial iOS build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ DerivedData/
 .vscode
 
 /build*/
+/install*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,22 @@
 
 # gtest_discover_tests requires v3.12
 # Currently the cmake version supported by Travis CI is 3.12.4
-cmake_minimum_required(VERSION 3.12)
+if (IOS)
+    # We use the most recent version of cmake for iOS builds as even the minor
+    # builds contain important patches
+    cmake_minimum_required(VERSION 3.17.2)
+else()
+    cmake_minimum_required(VERSION 3.12)
+endif()
 
+set(DECK_VERSION 0.0.1)
+set(DECK_SO_VERSION 1)
 project(
     deck.gl
     DESCRIPTION "C++ renderer for deck.gl"
     HOMEPAGE_URL "https://github.com/UnfoldedInc/deck.gl-native"
     LANGUAGES C CXX
+    VERSION ${DECK_VERSION}
     )
 
 # Global configuration
@@ -52,12 +61,19 @@ option(DECK_ENABLE_COVERAGE "Creates coverage reports if enabled" OFF)
 option(DECK_BUILD_EXAMPLES "Enables building examples" ON)
 option(DECK_BUILD_TESTS "Enables building tests" ON)
 option(DECK_ENABLE_GRAPHICS "When set to OFF, no graphics libraries will be included. Useful for running on CI" ON)
+option(DECK_USE_FRAMEWORKS "Whether or not to bundle libraries as frameworks on macOS and iOS" ON)
 
 # We're using clang-format-9 Linux package, which should have priority over any other version
 find_program(CLANG_FORMAT_PATH NAMES clang-format-9 clang-format)
 cmake_dependent_option(
     DECK_ENABLE_FORMAT "Enable running clang-format before compiling" ON
     "CLANG_FORMAT_PATH" OFF
+    )
+
+# If we're compiling for an Apple platform, use frameworks by default
+cmake_dependent_option(
+    DECK_USE_FRAMEWORKS "Whether or not to bundle libraries as frameworks on macOS and iOS" ON
+    APPLE OFF
     )
 
 # Default values for the backend-enabling options
@@ -96,7 +112,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(DECK_MODULES probe.gl math.gl loaders.gl luma.gl deck.gl)
 set(DECK_MODULE_PATH cpp/modules/)
 
-# Shared libraries
+# Configuration libraries
 set(DECK_CONFIG_LIBRARY deckgl-internal-config)
 
 # Global property that will be "topped-off" with example files
@@ -106,9 +122,11 @@ set_property(GLOBAL PROPERTY DECK_EXAMPLE_FILES "")
 # PLATFORM SETUP #
 ##################
 
-# TODO: This should be much more ellaborate if we want to get the actual CPU architecture
-# It's currently only used to determine appropriate include/linker paths
-if (APPLE)
+# Determine which architecture/OS we're building for
+# https://cmake.org/cmake/help/latest/variable/IOS.html
+if (IOS)
+    set(DECK_ARCH ${CMAKE_OSX_ARCHITECTURES}-ios)
+elseif (APPLE)
     set(DECK_ARCH x64-osx)
 elseif (UNIX)
     set(DECK_ARCH x64-linux)
@@ -141,9 +159,9 @@ if (NOT WIN32)
     endif()
 endif()
 
-####################
-# SHARED LIBRARIES #
-####################
+###########################
+# CONFIGURATION LIBRARIES #
+###########################
 
 add_library(${DECK_CONFIG_LIBRARY} INTERFACE)
 
@@ -191,10 +209,6 @@ endforeach()
 
 target_link_libraries(deckgl-bundle INTERFACE ${DECK_MODULES})
 
-if (DECK_BUILD_SHARED_LIBS)
-    set_target_properties(deckgl-bundle PROPERTIES SOVERSION 1)
-endif()
-
 ############
 # EXAMPLES #
 ############
@@ -226,7 +240,9 @@ if (DECK_BUILD_TESTS)
 
     target_sources(deckgl-bundle-tests PRIVATE cpp/tests/main.cpp)
     
-    find_library(gtest_LIB gtest PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
+    # We're using pre-built dependencies from our dependency submodule
+    # NO_DEFAULT_PATH and NO_CMAKE_FIND_ROOT_PATH make it so other lookup paths are ignored
+    find_library(gtest_LIB gtest PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
     target_link_libraries(deckgl-bundle-tests PRIVATE ${gtest_LIB} deckgl-bundle)
 
     # Extract registered Google Tests from the executable and add them to ctest

--- a/cpp/examples/deck.gl/CMakeLists.txt
+++ b/cpp/examples/deck.gl/CMakeLists.txt
@@ -33,9 +33,22 @@ set(EXAMPLE_DATA_FILES
 # Create an executable for each example from the list
 foreach(EXAMPLE_SOURCE_FILE ${EXAMPLE_SOURCE_FILES})
     get_filename_component(TARGET_NAME ${EXAMPLE_SOURCE_FILE} NAME_WE)
-    add_executable(${TARGET_NAME} ${EXAMPLE_SOURCE_FILE})
+    # Specify MACOSX_BUNDLE in order to get a bundled executable that can be ran 
+    # straight from Finderwhen building for macOS/iOS
+    # https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE.html
+    add_executable(${TARGET_NAME} MACOSX_BUNDLE ${EXAMPLE_SOURCE_FILE})
     
     target_link_libraries(${TARGET_NAME} PRIVATE ${DECK_LINK_FLAGS} deck.gl loaders.gl)
+
+    # Installation
+    install(TARGETS ${TARGET_NAME}
+        RUNTIME
+            DESTINATION examples/deck.gl
+            COMPONENT Examples
+        BUNDLE
+            DESTINATION examples/deck.gl
+            COMPONENT Examples
+        )
 endforeach()
 
 # Copy supporting data files

--- a/cpp/examples/luma.gl/CMakeLists.txt
+++ b/cpp/examples/luma.gl/CMakeLists.txt
@@ -25,9 +25,22 @@ set(EXAMPLE_SOURCE_FILES
 # Create an executable for each example from the list
 foreach(EXAMPLE_SOURCE_FILE ${EXAMPLE_SOURCE_FILES})
     get_filename_component(TARGET_NAME ${EXAMPLE_SOURCE_FILE} NAME_WE)
-    add_executable(${TARGET_NAME} ${EXAMPLE_SOURCE_FILE})
+    # Specify MACOSX_BUNDLE in order to get a bundled executable that can be ran 
+    # straight from Finderwhen building for macOS/iOS
+    # https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE.html
+    add_executable(${TARGET_NAME} MACOSX_BUNDLE ${EXAMPLE_SOURCE_FILE})
     
     target_link_libraries(${TARGET_NAME} PUBLIC ${DECK_LINK_FLAGS} luma.gl probe.gl math.gl)
+
+    # Installation
+    install(TARGETS ${TARGET_NAME}
+        RUNTIME
+            DESTINATION examples/luma.gl
+            COMPONENT Examples
+        BUNDLE
+            DESTINATION examples/luma.gl
+            COMPONENT Examples
+        )
 endforeach()
 
 # Add example files to global DECK_EXAMPLE_FILES property

--- a/cpp/modules/deck.gl/CMakeLists.txt
+++ b/cpp/modules/deck.gl/CMakeLists.txt
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 add_library(deck.gl)
+set_target_properties(deck.gl PROPERTIES VERSION ${DECK_VERSION})
+set_target_properties(deck.gl PROPERTIES SOVERSION ${DECK_SO_VERSION})
 
 # File lists that are maintained manually
 
@@ -135,9 +137,11 @@ set(TESTS_SOURCE_FILE_LIST
     ${LAYERS_TEST_SOURCE_FILES}
     )
 
-find_library(arrow_LIB arrow PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
-find_library(jsoncpp_LIB jsoncpp PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
-find_library(fmt_LIB fmt PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
+# We're using pre-built dependencies from our dependency submodule
+# NO_DEFAULT_PATH and NO_CMAKE_FIND_ROOT_PATH make it so other lookup paths are ignored
+find_library(arrow_LIB arrow PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+find_library(jsoncpp_LIB jsoncpp PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+find_library(fmt_LIB fmt PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
 
 target_link_libraries(deck.gl PUBLIC ${DECK_LINK_FLAGS} ${DECK_SHARED_LIB}
     probe.gl math.gl luma.gl ${arrow_LIB} ${jsoncpp_LIB} ${fmt_LIB})
@@ -158,3 +162,40 @@ set_property(TARGET deck.gl PROPERTY DECK_ALL_SOURCES ${MODULE_SOURCE_FILES})
 set(MODULE_TEST_FILES ${TESTS_SOURCE_FILE_LIST})
 list(TRANSFORM MODULE_TEST_FILES PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
 set_property(TARGET deck.gl PROPERTY DECK_TEST_SOURCES ${MODULE_TEST_FILES})
+
+# Installation
+install(TARGETS deck.gl
+    LIBRARY
+        DESTINATION lib
+        COMPONENT Libraries
+    )
+
+# In order to maintain the hierarchy within this module, we install the files
+# one by one into appropriate directories
+foreach (HEADER_FILE ${HEADER_FILE_LIST})
+    get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # If we're using frameworks, there's no need for install directory as frameworks contain headers
+    if (NOT DECK_USE_FRAMEWORKS)
+        install(FILES ${HEADER_FILE} 
+            DESTINATION include/deck.gl/${HEADER_DIRECTORY}
+            COMPONENT Development
+            )
+    else()
+        # Provide a prefix directory so that headers are not flattened
+        set_source_files_properties(${HEADER_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/${HEADER_DIRECTORY})
+    endif()
+endforeach()
+
+if (DECK_USE_FRAMEWORKS)
+    # Specyfing PUBLIC_HEADER in set_target_properties currently flattens the hierarchy which we do not want
+    # The workaround is to specify these as sources in combination with prefix addition above
+    # https://gitlab.kitware.com/cmake/cmake/issues/16739
+    target_sources(deck.gl PRIVATE ${HEADER_FILE_LIST})
+
+    set_target_properties(deck.gl PROPERTIES
+        FRAMEWORK ${DECK_USE_FRAMEWORKS}
+        FRAMEWORK_VERSION ${DECK_VERSION}
+        MACOSX_FRAMEWORK_IDENTIFIER ai.unfolded.deckgl
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${DECK_VERSION}
+        )
+endif()

--- a/cpp/modules/deck.gl/CMakeLists.txt
+++ b/cpp/modules/deck.gl/CMakeLists.txt
@@ -168,6 +168,9 @@ install(TARGETS deck.gl
     LIBRARY
         DESTINATION lib
         COMPONENT Libraries
+    ARCHIVE
+        DESTINATION lib
+        COMPONENT Libraries
     )
 
 # In order to maintain the hierarchy within this module, we install the files

--- a/cpp/modules/loaders.gl/CMakeLists.txt
+++ b/cpp/modules/loaders.gl/CMakeLists.txt
@@ -19,10 +19,14 @@
 # THE SOFTWARE.
 
 add_library(loaders.gl)
+set_target_properties(loaders.gl PROPERTIES VERSION ${DECK_VERSION})
+set_target_properties(loaders.gl PROPERTIES SOVERSION ${DECK_SO_VERSION})
 
 # File lists that are maintained manually
 set(HEADER_FILE_LIST
+    csv.h
     csv/src/csv-loader.h
+    json.h
     json/src/json-loader.h
     )
 set(SOURCE_FILE_LIST
@@ -34,7 +38,9 @@ set(TESTS_SOURCE_FILE_LIST
     json/test/json-loader-test.cpp
     )
 
-find_library(arrow_LIB arrow PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
+# We're using pre-built dependencies from our dependency submodule
+# NO_DEFAULT_PATH and NO_CMAKE_FIND_ROOT_PATH make it so other lookup paths are ignored
+find_library(arrow_LIB arrow PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
 
 target_link_libraries(loaders.gl PUBLIC ${DECK_LINK_FLAGS} ${arrow_LIB})
 target_link_libraries(loaders.gl PUBLIC ${DECK_CONFIG_LIBRARY})
@@ -54,3 +60,40 @@ set_property(TARGET loaders.gl PROPERTY DECK_ALL_SOURCES ${MODULE_SOURCE_FILES})
 set(MODULE_TEST_FILES ${TESTS_SOURCE_FILE_LIST})
 list(TRANSFORM MODULE_TEST_FILES PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
 set_property(TARGET loaders.gl PROPERTY DECK_TEST_SOURCES ${MODULE_TEST_FILES})
+
+# Installation
+install(TARGETS loaders.gl
+    LIBRARY
+        DESTINATION lib
+        COMPONENT Libraries
+    )
+
+# In order to maintain the hierarchy within this module, we install the files
+# one by one into appropriate directories
+foreach (HEADER_FILE ${HEADER_FILE_LIST})
+    get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # If we're using frameworks, there's no need for install directory as frameworks contain headers
+    if (NOT DECK_USE_FRAMEWORKS)
+        install(FILES ${HEADER_FILE} 
+            DESTINATION include/loaders.gl/${HEADER_DIRECTORY}
+            COMPONENT Development
+            )
+    else()
+        # Provide a prefix directory so that headers are not flattened
+        set_source_files_properties(${HEADER_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/${HEADER_DIRECTORY})
+    endif()
+endforeach()
+
+if (DECK_USE_FRAMEWORKS)
+    # Specyfing PUBLIC_HEADER in set_target_properties currently flattens the hierarchy which we do not want
+    # The workaround is to specify these as sources in combination with prefix addition above
+    # https://gitlab.kitware.com/cmake/cmake/issues/16739
+    target_sources(loaders.gl PRIVATE ${HEADER_FILE_LIST})
+
+    set_target_properties(loaders.gl PROPERTIES
+        FRAMEWORK ${DECK_USE_FRAMEWORKS}
+        FRAMEWORK_VERSION ${DECK_VERSION}
+        MACOSX_FRAMEWORK_IDENTIFIER ai.unfolded.loadersgl
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${DECK_VERSION}
+        )
+endif()

--- a/cpp/modules/loaders.gl/CMakeLists.txt
+++ b/cpp/modules/loaders.gl/CMakeLists.txt
@@ -66,6 +66,9 @@ install(TARGETS loaders.gl
     LIBRARY
         DESTINATION lib
         COMPONENT Libraries
+    ARCHIVE
+        DESTINATION lib
+        COMPONENT Libraries
     )
 
 # In order to maintain the hierarchy within this module, we install the files

--- a/cpp/modules/luma.gl/CMakeLists.txt
+++ b/cpp/modules/luma.gl/CMakeLists.txt
@@ -198,6 +198,9 @@ install(TARGETS luma.gl
     LIBRARY
         DESTINATION lib
         COMPONENT Libraries
+    ARCHIVE
+        DESTINATION lib
+        COMPONENT Libraries
     )
 
 # In order to maintain the hierarchy within this module, we install the files

--- a/cpp/modules/luma.gl/CMakeLists.txt
+++ b/cpp/modules/luma.gl/CMakeLists.txt
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 add_library(luma.gl)
+set_target_properties(luma.gl PROPERTIES VERSION ${DECK_VERSION})
+set_target_properties(luma.gl PROPERTIES SOVERSION ${DECK_SO_VERSION})
 
 # File lists that are maintained manually
 set(WEBGPU_HEADER_FILE_LIST
@@ -29,14 +31,12 @@ set(WEBGPU_HEADER_FILE_LIST
     webgpu/src/webgpu-constants.h
     webgpu/src/webgpu-utils.h
     webgpu/src/webgpu-helpers.h
-    webgpu/src/backends/backend-binding.h
     )
 set(WEBGPU_SOURCE_FILE_LIST
     webgpu/src/combo-render-pipeline-descriptor.cpp
     webgpu/src/shaderc-utils.cpp
     webgpu/src/webgpu-utils.cpp
     webgpu/src/webgpu-helpers.cpp
-    webgpu/src/backends/backend-binding.cpp
     )
 set(WEBGPU_TESTS_SOURCE_FILE_LIST
     webgpu/test/webgpu-test.cpp
@@ -64,66 +64,87 @@ set(GARROW_TESTS_SOURCE_FILE_LIST
     garrow/test/util/arrow-utils-test.cc
     )
 
-set(HEADER_FILE_LIST
+set(CORE_HEADER_FILE_LIST
     core.h
     core/src/animation-loop.h
-    core/src/glfw-animation-loop.h
     core/src/model.h
     core/src/blit-model.h
     core/src/size.h
     )
-set(SOURCE_FILE_LIST
+set(CORE_SOURCE_FILE_LIST
     core/src/animation-loop.cpp
-    core/src/glfw-animation-loop.cpp
     core/src/model.cpp
     core/src/blit-model.cc
     )
-set(TESTS_SOURCE_FILE_LIST
+set(CORE_TESTS_SOURCE_FILE_LIST
     )
 
-find_library(dawn_proc_LIB dawn_proc PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
-find_library(dawn_native_LIB dawn_native PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
-find_library(glfw_LIB glfw PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
-find_library(shaderc_LIB shaderc_combined PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
-find_library(arrow_LIB arrow PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
+# We're using pre-built dependencies from our dependency submodule
+# NO_DEFAULT_PATH and NO_CMAKE_FIND_ROOT_PATH make it so other lookup paths are ignored
+find_library(dawn_proc_LIB dawn_proc PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+find_library(dawn_native_LIB dawn_native PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+find_library(arrow_LIB arrow PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+find_library(shaderc_LIB shaderc_combined PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
 
 target_link_libraries(luma.gl PUBLIC ${DECK_LINK_FLAGS}
     ${dawn_proc_LIB}
     ${dawn_native_LIB}
-    ${glfw_LIB}
-    ${shaderc_LIB}
     ${arrow_LIB}
+    ${shaderc_LIB}
     ${DECK_DEPS_PATH}/webgpu_cpp.o
     )
 target_link_libraries(luma.gl PUBLIC ${DECK_CONFIG_LIBRARY} math.gl probe.gl)
-if (NOT APPLE)
-    # TODO: Check if still needed
-    target_link_libraries(luma.gl PUBLIC -pthread -ldl -lX11)
+
+# All the supported platforms except iOS use GLFW
+if (NOT IOS)
+    set(LUMAGL_USES_GLFW TRUE)
 endif()
 
-# GLFW dependencies
-if (APPLE)
-    find_library(Cocoa_LIB Cocoa)
-    find_library(IOKit_LIB IOKit)
-    find_library(CoreFoundation_LIB CoreFoundation)
-    find_library(CoreVideo_LIB CoreVideo)
-    target_link_libraries(luma.gl PUBLIC ${DECK_LINK_FLAGS}
-        ${Cocoa_LIB}
-        ${IOKit_LIB}
-        ${CoreFoundation_LIB}
-        ${CoreVideo_LIB}
-        )
+if (LUMAGL_USES_GLFW)
+    list(APPEND WEBGPU_HEADER_FILE_LIST webgpu/src/backends/backend-binding.h)
+    list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/backend-binding.cpp)
+
+    list(APPEND CORE_HEADER_FILE_LIST core/src/glfw-animation-loop.h)
+    list(APPEND CORE_SOURCE_FILE_LIST core/src/glfw-animation-loop.cpp)
+
+    find_library(glfw_LIB glfw PATH ${DECK_DEPS_PATH} NO_DEFAULT_PATH)
+    target_link_libraries(luma.gl PUBLIC ${DECK_CONFIG_LIBRARY} ${glfw_LIB})
+
+    # macOS requires additional frameworks to be linked
+    if (APPLE)
+        find_library(Cocoa_LIB Cocoa)
+        find_library(IOKit_LIB IOKit)
+        find_library(CoreFoundation_LIB CoreFoundation)
+        find_library(CoreVideo_LIB CoreVideo)
+        target_link_libraries(luma.gl PUBLIC ${DECK_LINK_FLAGS}
+            ${Cocoa_LIB}
+            ${IOKit_LIB}
+            ${CoreFoundation_LIB}
+            ${CoreVideo_LIB}
+            )
+    endif()
+endif()
+
+# Additional Linux setup
+if (UNIX AND NOT APPLE)
+    # TODO(isaac@unfolded.ai): Check if still needed
+    target_link_libraries(luma.gl PUBLIC -pthread -ldl -lX11)
 endif()
 
 # Backend specific files and libraries
 if (DECK_ENABLE_D3D12)
-    list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/d3d12-binding.cpp)
+    if (LUMAGL_USES_GLFW)
+        list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/d3d12-binding.cpp)
+    endif()
+
     # TODO: Currently not supported. Should link against D3D12 libs
 endif()
 if (DECK_ENABLE_METAL)
-    list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/metal-binding.mm)
+    if (LUMAGL_USES_GLFW)
+        list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/metal-binding.mm)
+    endif()
 
-    # macOS frameworks related to Metal
+    # Frameworks related to Metal
     find_library(Metal_LIB Metal)
     find_library(QuartzCore_LIB QuartzCore)
     find_library(IOKit_LIB IOKit)
@@ -136,29 +157,75 @@ if (DECK_ENABLE_METAL)
         )
 endif()
 if (DECK_ENABLE_NULL)
-    list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/null-binding.cpp)
+    if (LUMAGL_USES_GLFW)
+        list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/null-binding.cpp)
+    endif()
 endif()
 if (DECK_ENABLE_OPENGL)
-    list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/opengl-binding.cpp)
+    if (LUMAGL_USES_GLFW)
+        list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/opengl-binding.cpp)
+    endif()
 endif()
 if (DECK_ENABLE_VULKAN)
-    list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/vulkan-binding.cpp)
+    if (LUMAGL_USES_GLFW)
+        list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/vulkan-binding.cpp)
+    endif()
 endif()
 
+set(HEADER_FILE_LIST ${WEBGPU_HEADER_FILE_LIST} ${GARROW_HEADER_FILE_LIST} ${CORE_HEADER_FILE_LIST})
+set(SOURCE_FILE_LIST ${WEBGPU_SOURCE_FILE_LIST} ${GARROW_SOURCE_FILE_LIST} ${CORE_SOURCE_FILE_LIST})
+set(TESTS_SOURCE_FILE_LIST ${WEBGPU_TESTS_SOURCE_FILE_LIST} ${GARROW_TESTS_SOURCE_FILE_LIST} ${CORE_TESTS_SOURCE_FILE_LIST})
+
 # Specify sources that'll be compiled
-target_sources(luma.gl PRIVATE ${SOURCE_FILE_LIST} ${WEBGPU_SOURCE_FILE_LIST} ${GARROW_SOURCE_FILE_LIST})
+target_sources(luma.gl PRIVATE ${SOURCE_FILE_LIST})
 
 # Export source list of this module
 # NOTE: We transform relative paths to absolute paths before exporting
 set(MODULE_SOURCE_FILES
-    ${WEBGPU_HEADER_FILE_LIST} ${WEBGPU_SOURCE_FILE_LIST}
-    ${GARROW_HEADER_FILE_LIST} ${GARROW_SOURCE_FILE_LIST}
-    ${HEADER_FILE_LIST} ${SOURCE_FILE_LIST}
-    ${WEBGPU_TESTS_SOURCE_FILE_LIST} ${GARROW_TESTS_SOURCE_FILE_LIST} ${TESTS_SOURCE_FILE_LIST}
+    ${HEADER_FILE_LIST}
+    ${SOURCE_FILE_LIST}
+    ${TESTS_SOURCE_FILE_LIST}
     )
 list(TRANSFORM MODULE_SOURCE_FILES PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
 set_property(TARGET luma.gl PROPERTY DECK_ALL_SOURCES ${MODULE_SOURCE_FILES})
 
-set(MODULE_TEST_FILES ${TESTS_SOURCE_FILE_LIST} ${WEBGPU_TESTS_SOURCE_FILE_LIST} ${GARROW_TESTS_SOURCE_FILE_LIST})
+set(MODULE_TEST_FILES ${TESTS_SOURCE_FILE_LIST})
 list(TRANSFORM MODULE_TEST_FILES PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
 set_property(TARGET luma.gl PROPERTY DECK_TEST_SOURCES ${MODULE_TEST_FILES})
+
+# Installation
+install(TARGETS luma.gl
+    LIBRARY
+        DESTINATION lib
+        COMPONENT Libraries
+    )
+
+# In order to maintain the hierarchy within this module, we install the files
+# one by one into appropriate directories
+foreach (HEADER_FILE ${HEADER_FILE_LIST})
+    get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # If we're using frameworks, there's no need for install directory as frameworks contain headers
+    if (NOT DECK_USE_FRAMEWORKS)
+        install(FILES ${HEADER_FILE} 
+            DESTINATION include/luma.gl/${HEADER_DIRECTORY}
+            COMPONENT Development
+            )
+    else()
+        # Provide a prefix directory so that headers are not flattened
+        set_source_files_properties(${HEADER_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/${HEADER_DIRECTORY})
+    endif()
+endforeach()
+
+if (DECK_USE_FRAMEWORKS)
+    # Specyfing PUBLIC_HEADER in set_target_properties currently flattens the hierarchy which we do not want
+    # The workaround is to specify these as sources in combination with prefix addition above
+    # https://gitlab.kitware.com/cmake/cmake/issues/16739
+    target_sources(luma.gl PRIVATE ${HEADER_FILE_LIST})
+
+    set_target_properties(luma.gl PROPERTIES
+        FRAMEWORK ${DECK_USE_FRAMEWORKS}
+        FRAMEWORK_VERSION ${DECK_VERSION}
+        MACOSX_FRAMEWORK_IDENTIFIER ai.unfolded.lumagl
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${DECK_VERSION}
+        )
+endif()

--- a/cpp/modules/math.gl/CMakeLists.txt
+++ b/cpp/modules/math.gl/CMakeLists.txt
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 add_library(math.gl)
+set_target_properties(math.gl PROPERTIES VERSION ${DECK_VERSION})
+set_target_properties(math.gl PROPERTIES SOVERSION ${DECK_SO_VERSION})
 
 # File lists that are maintained manually
 set(HEADER_FILE_LIST
@@ -56,3 +58,40 @@ set_property(TARGET math.gl PROPERTY DECK_ALL_SOURCES ${MODULE_SOURCE_FILES})
 set(MODULE_TEST_FILES ${TESTS_SOURCE_FILE_LIST})
 list(TRANSFORM MODULE_TEST_FILES PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
 set_property(TARGET math.gl PROPERTY DECK_TEST_SOURCES ${MODULE_TEST_FILES})
+
+# Installation
+install(TARGETS math.gl
+    LIBRARY
+        DESTINATION lib
+        COMPONENT Libraries
+    )
+
+# In order to maintain the hierarchy within this module, we install the files
+# one by one into appropriate directories
+foreach (HEADER_FILE ${HEADER_FILE_LIST})
+    get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # If we're using frameworks, there's no need for install directory as frameworks contain headers
+    if (NOT DECK_USE_FRAMEWORKS)
+        install(FILES ${HEADER_FILE} 
+            DESTINATION include/math.gl/${HEADER_DIRECTORY}
+            COMPONENT Development
+            )
+    else()
+        # Provide a prefix directory so that headers are not flattened
+        set_source_files_properties(${HEADER_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/${HEADER_DIRECTORY})
+    endif()
+endforeach()
+
+if (DECK_USE_FRAMEWORKS)
+    # Specyfing PUBLIC_HEADER in set_target_properties currently flattens the hierarchy which we do not want
+    # The workaround is to specify these as sources in combination with prefix addition above
+    # https://gitlab.kitware.com/cmake/cmake/issues/16739
+    target_sources(math.gl PRIVATE ${HEADER_FILE_LIST})
+
+    set_target_properties(math.gl PROPERTIES
+        FRAMEWORK ${DECK_USE_FRAMEWORKS}
+        FRAMEWORK_VERSION ${DECK_VERSION}
+        MACOSX_FRAMEWORK_IDENTIFIER ai.unfolded.mathgl
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${DECK_VERSION}
+        )
+endif()

--- a/cpp/modules/math.gl/CMakeLists.txt
+++ b/cpp/modules/math.gl/CMakeLists.txt
@@ -64,6 +64,9 @@ install(TARGETS math.gl
     LIBRARY
         DESTINATION lib
         COMPONENT Libraries
+    ARCHIVE
+        DESTINATION lib
+        COMPONENT Libraries
     )
 
 # In order to maintain the hierarchy within this module, we install the files

--- a/cpp/modules/probe.gl/CMakeLists.txt
+++ b/cpp/modules/probe.gl/CMakeLists.txt
@@ -65,6 +65,9 @@ install(TARGETS probe.gl
     LIBRARY
         DESTINATION lib
         COMPONENT Libraries
+    ARCHIVE
+        DESTINATION lib
+        COMPONENT Libraries
     )
 
 # In order to maintain the hierarchy within this module, we install the files

--- a/cpp/modules/probe.gl/CMakeLists.txt
+++ b/cpp/modules/probe.gl/CMakeLists.txt
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 add_library(probe.gl)
+set_target_properties(probe.gl PROPERTIES VERSION ${DECK_VERSION})
+set_target_properties(probe.gl PROPERTIES SOVERSION ${DECK_SO_VERSION})
 
 # File lists that are maintained manually
 set(HEADER_FILE_LIST
@@ -57,3 +59,40 @@ set_property(TARGET probe.gl PROPERTY DECK_ALL_SOURCES ${MODULE_SOURCE_FILES})
 set(MODULE_TEST_FILES ${TESTS_SOURCE_FILE_LIST})
 list(TRANSFORM MODULE_TEST_FILES PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
 set_property(TARGET probe.gl PROPERTY DECK_TEST_SOURCES ${MODULE_TEST_FILES})
+
+# Installation
+install(TARGETS probe.gl
+    LIBRARY
+        DESTINATION lib
+        COMPONENT Libraries
+    )
+
+# In order to maintain the hierarchy within this module, we install the files
+# one by one into appropriate directories
+foreach (HEADER_FILE ${HEADER_FILE_LIST})
+    get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # If we're using frameworks, there's no need for install directory as frameworks contain headers
+    if (NOT DECK_USE_FRAMEWORKS)
+        install(FILES ${HEADER_FILE} 
+            DESTINATION include/probe.gl/${HEADER_DIRECTORY}
+            COMPONENT Development
+            )
+    else()
+        # Provide a prefix directory so that headers are not flattened
+        set_source_files_properties(${HEADER_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/${HEADER_DIRECTORY})
+    endif()
+endforeach()
+
+if (DECK_USE_FRAMEWORKS)
+    # Specyfing PUBLIC_HEADER in set_target_properties currently flattens the hierarchy which we do not want
+    # The workaround is to specify these as sources in combination with prefix addition above
+    # https://gitlab.kitware.com/cmake/cmake/issues/16739
+    target_sources(probe.gl PRIVATE ${HEADER_FILE_LIST})
+
+    set_target_properties(probe.gl PROPERTIES
+        FRAMEWORK ${DECK_USE_FRAMEWORKS}
+        FRAMEWORK_VERSION ${DECK_VERSION}
+        MACOSX_FRAMEWORK_IDENTIFIER ai.unfolded.probegl
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${DECK_VERSION}
+        )
+endif()


### PR DESCRIPTION
- Added `install` step to all the library and example targets so that they can be used externally
- macOS/iOS installations produce `.framework` files for libraries, and bundles for examples. Installing on Linux should result `include`/`lib`/`example` directories with static/dynamic libraries in `lib` based on cmake config
- Initial iOS build setup

Due to our current project structure, creating a nice `include` directory with headers is somewhat tricky. I managed to make it retain the hierarchy we have in place, as by default it gets flattened out, but even this isn't ideal as we have `src` directory in there. Perhaps we want to consider moving out public headers into their own `include` directory within the project?

@isaacbrodsky if possible, can you double check there are no issues installing on Linux:
```
cmake -S . -B build -DCMAKE_INSTALL_PREFIX=`pwd`/install
cmake --build build --target install -j 16
```
This should result in `install` directory populated with artifacts mentioned above. I plan on updating existing scripts and providing additional ones in a followup PR