### PR TITLE
Build scripts revisited, build config tuneup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ DerivedData/
 
 /build*/
 /install*/
+Testing

--- a/cpp/examples/deck.gl/CMakeLists.txt
+++ b/cpp/examples/deck.gl/CMakeLists.txt
@@ -36,10 +36,7 @@ set(EXAMPLE_DATA_FILES
 # Create an executable for each example from the list
 foreach(EXAMPLE_SOURCE_FILE ${EXAMPLE_SOURCE_FILES})
     get_filename_component(TARGET_NAME ${EXAMPLE_SOURCE_FILE} NAME_WE)
-    # Specify MACOSX_BUNDLE in order to get a bundled executable that can be ran 
-    # straight from Finderwhen building for macOS/iOS
-    # https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE.html
-    add_executable(${TARGET_NAME} MACOSX_BUNDLE ${EXAMPLE_SOURCE_FILE})
+    add_executable(${TARGET_NAME} ${EXAMPLE_SOURCE_FILE})
     
     target_link_libraries(${TARGET_NAME} PRIVATE ${DECK_LINK_FLAGS} deck.gl loaders.gl)
 

--- a/cpp/examples/luma.gl/CMakeLists.txt
+++ b/cpp/examples/luma.gl/CMakeLists.txt
@@ -25,10 +25,7 @@ set(EXAMPLE_SOURCE_FILES
 # Create an executable for each example from the list
 foreach(EXAMPLE_SOURCE_FILE ${EXAMPLE_SOURCE_FILES})
     get_filename_component(TARGET_NAME ${EXAMPLE_SOURCE_FILE} NAME_WE)
-    # Specify MACOSX_BUNDLE in order to get a bundled executable that can be ran 
-    # straight from Finderwhen building for macOS/iOS
-    # https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE.html
-    add_executable(${TARGET_NAME} MACOSX_BUNDLE ${EXAMPLE_SOURCE_FILE})
+    add_executable(${TARGET_NAME} ${EXAMPLE_SOURCE_FILE})
     
     target_link_libraries(${TARGET_NAME} PUBLIC ${DECK_LINK_FLAGS} luma.gl probe.gl math.gl)
 

--- a/cpp/modules/deck.gl/CMakeLists.txt
+++ b/cpp/modules/deck.gl/CMakeLists.txt
@@ -181,6 +181,10 @@ install(TARGETS deck.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # Get rid of src directory from include path
+    if (HEADER_DIRECTORY)
+        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
+    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/cpp/modules/loaders.gl/CMakeLists.txt
+++ b/cpp/modules/loaders.gl/CMakeLists.txt
@@ -75,6 +75,10 @@ install(TARGETS loaders.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # Get rid of src directory from include path
+    if (HEADER_DIRECTORY)
+        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
+    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/cpp/modules/luma.gl/CMakeLists.txt
+++ b/cpp/modules/luma.gl/CMakeLists.txt
@@ -210,6 +210,10 @@ install(TARGETS luma.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # Get rid of src directory from include path
+    if (HEADER_DIRECTORY)
+        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
+    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/cpp/modules/luma.gl/core/src/animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/animation-loop.cpp
@@ -20,6 +20,8 @@
 
 #include "./animation-loop.h"  // NOLINT(build/include)
 
+#include <dawn_native/DawnNative.h>
+
 #include <functional>
 
 #include "luma.gl/webgpu.h"

--- a/cpp/modules/math.gl/CMakeLists.txt
+++ b/cpp/modules/math.gl/CMakeLists.txt
@@ -73,6 +73,10 @@ install(TARGETS math.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # Get rid of src directory from include path
+    if (HEADER_DIRECTORY)
+        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
+    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/cpp/modules/probe.gl/CMakeLists.txt
+++ b/cpp/modules/probe.gl/CMakeLists.txt
@@ -74,6 +74,10 @@ install(TARGETS probe.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
+    # Get rid of src directory from include path
+    if (HEADER_DIRECTORY)
+        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
+    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/scripts/build-clang.sh
+++ b/scripts/build-clang.sh
@@ -2,9 +2,6 @@
 
 # Note when switching compiler: `rm -fr build`
 
-mkdir -p build/clang
-cd build/clang
-cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ../..
-make -j 16
-ctest --output-on-failure
-# make test #  same output as `ctest`?
+cmake -S . -B build/clang -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+cmake --build build/clang -j 16
+build/clang/deckgl-bundle-tests

--- a/scripts/build-cpplint.sh
+++ b/scripts/build-cpplint.sh
@@ -2,9 +2,6 @@
 
 # Note when switching compiler: `rm -fr build`
 
-mkdir -p build/cpplint
-cd build/cpplint
-cmake "-DCMAKE_CXX_CPPLINT=cpplint" ../..
-make -j 16
-ctest --output-on-failure
-# make test #  same output as `ctest`?
+cmake -S . -B build/cpplint -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 -DCMAKE_CXX_CPPLINT=cpplint
+cmake --build build/cpplint -j 16
+build/clang/deckgl-bundle-tests

--- a/scripts/build-gcc.sh
+++ b/scripts/build-gcc.sh
@@ -2,9 +2,6 @@
 
 # Note when switching compiler: `rm -fr build`
 
-mkdir -p build/gcc
-cd build/gcc
-cmake -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 ../..
-make -j 16
-ctest --output-on-failure
-# make test #  same output as `ctest`?
+cmake -S . -B build/gcc -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9
+cmake --build build/gcc -j 16
+build/clang/deckgl-bundle-tests

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+# The following are paired together in order to form a build target
+declare -a archs=("arm64" "arm64e" "x86_64")
+declare -a sysroots=("iphoneos" "iphoneos" "iphonesimulator")
+declare -a deployment_targets=("12.0" "12.0" "13.0")
+
+install_dir="`pwd`/install"
+
+# Build for each architecture individually
+for i in $(seq 0 $((${#archs[@]}-1))) # {0..${#archs[@]}}
+do
+  cmake -S . -B build/${archs[$i]} -GXcode -DCMAKE_INSTALL_PREFIX=$install_dir/${archs[$i]} -DDECK_BUILD_EXAMPLES=OFF -DDECK_BUILD_TESTS=OFF -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=${archs[$i]} -DCMAKE_OSX_SYSROOT=${sysroots[$i]} -DCMAKE_OSX_DEPLOYMENT_TARGET=${deployment_targets[$i]} -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO -DCMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE=NO
+  cmake --build build/${archs[$i]} --config Debug --target install -j 16
+done
+
+# Copy over a set of frameworks we'll use as a base
+mkdir -p install/combined/lib
+cp -r install/${archs[0]}/lib/* install/combined/lib
+
+## Declare the modules we're building, and iterate over them to combine the framework architectures
+declare -a modules=("deck.gl" "luma.gl" "loaders.gl" "math.gl" "probe.gl")
+for module in ${modules[@]}
+do
+  command="lipo -create "
+  for arch in ${archs[@]}
+  do
+    command="$command $install_dir/$arch/lib/$module.framework/$module "
+  done
+  command="$command -output $install_dir/combined/lib/$module.framework/$module"
+  eval $command
+done


### PR DESCRIPTION
- Minor updates to current set of build scripts
- Added `build-ios.sh` that builds all the supported architectures, and merges them into a single framework
- Got rid of `src` folder within `includes`