### PR TITLE
Reverted header install paths

### DIFF
--- a/cpp/modules/deck.gl/CMakeLists.txt
+++ b/cpp/modules/deck.gl/CMakeLists.txt
@@ -181,10 +181,6 @@ install(TARGETS deck.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
-    # Get rid of src directory from include path
-    if (HEADER_DIRECTORY)
-        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
-    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/cpp/modules/loaders.gl/CMakeLists.txt
+++ b/cpp/modules/loaders.gl/CMakeLists.txt
@@ -75,10 +75,6 @@ install(TARGETS loaders.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
-    # Get rid of src directory from include path
-    if (HEADER_DIRECTORY)
-        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
-    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/cpp/modules/luma.gl/CMakeLists.txt
+++ b/cpp/modules/luma.gl/CMakeLists.txt
@@ -210,10 +210,6 @@ install(TARGETS luma.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
-    # Get rid of src directory from include path
-    if (HEADER_DIRECTORY)
-        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
-    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/cpp/modules/math.gl/CMakeLists.txt
+++ b/cpp/modules/math.gl/CMakeLists.txt
@@ -73,10 +73,6 @@ install(TARGETS math.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
-    # Get rid of src directory from include path
-    if (HEADER_DIRECTORY)
-        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
-    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 

--- a/cpp/modules/probe.gl/CMakeLists.txt
+++ b/cpp/modules/probe.gl/CMakeLists.txt
@@ -74,10 +74,6 @@ install(TARGETS probe.gl
 # one by one into appropriate directories
 foreach (HEADER_FILE ${HEADER_FILE_LIST})
     get_filename_component(HEADER_DIRECTORY ${HEADER_FILE} DIRECTORY)
-    # Get rid of src directory from include path
-    if (HEADER_DIRECTORY)
-        string(REPLACE "/src" "" HEADER_DIRECTORY ${HEADER_DIRECTORY})
-    endif()
     # If we're using frameworks, there's no need for install directory as frameworks contain headers
     if (NOT DECK_USE_FRAMEWORKS)
         install(FILES ${HEADER_FILE} 


### PR DESCRIPTION
This ended up being a silly change, while it did update the directory structure, it obviously messed up inter-header includes as the paths are not correct