### PR TITLE
Unused API cleanup and tuneups

### DIFF
--- a/cpp/modules/deck.gl/core/src/lib/component.h
+++ b/cpp/modules/deck.gl/core/src/lib/component.h
@@ -21,12 +21,7 @@
 #ifndef DECKGL_CORE_LIB_COMPONENT_H
 #define DECKGL_CORE_LIB_COMPONENT_H
 
-#include <functional>
-#include <iostream>
-#include <list>
-#include <map>
 #include <memory>
-#include <string>
 
 #include "deck.gl/json.h"  // {JSONObject}
 
@@ -45,8 +40,8 @@ class Component {
 class Component::Props : public JSONObject {
  public:
   using super = JSONObject;
-  virtual auto makeComponent(std::shared_ptr<Component::Props> props) const -> Component* {
-    return new Component{std::dynamic_pointer_cast<Component::Props>(props)};
+  virtual auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> {
+    return std::make_shared<Component>(std::dynamic_pointer_cast<Component::Props>(props));
   }
 };
 

--- a/cpp/modules/deck.gl/core/src/lib/constants.h
+++ b/cpp/modules/deck.gl/core/src/lib/constants.h
@@ -46,7 +46,7 @@ enum class COORDINATE_SYSTEM {
 
 auto operator<<(std::ostream& os, COORDINATE_SYSTEM cs) -> std::ostream&;
 
-// TODO(ib) - decide how to deserialize enum constants
+// TODO(ib@unfolded.ai): Decide how to deserialize enum constants
 template <>
 inline auto fromJson<COORDINATE_SYSTEM>(const Json::Value& jsonValue) -> COORDINATE_SYSTEM {
   return static_cast<COORDINATE_SYSTEM>(fromJson<int>(jsonValue));

--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -29,7 +29,6 @@ using namespace deckgl;
 
 // Setters and getters for properties
 // TODO(ib@unfolded.ai): auto generate from language-independent prop definition schema
-
 static const std::vector<const Property*> propTypeDefs = {
     new PropertyT<std::list<std::shared_ptr<Layer::Props>>>{
         "layers", [](const JSONObject* props) { return dynamic_cast<const Deck::Props*>(props)->layers; },
@@ -58,8 +57,6 @@ auto Deck::Props::getProperties() const -> const Properties* {
   return &properties;
 }
 
-// Deck class
-
 Deck::Deck(std::shared_ptr<Deck::Props> props)
     : Component(props), width{props->width}, height{props->height}, _needsRedraw{"Initial render"} {
   this->animationLoop = lumagl::AnimationLoopFactory::createAnimationLoop(props->drawingOptions);
@@ -75,14 +72,9 @@ Deck::Deck(std::shared_ptr<Deck::Props> props)
       lumagl::utils::createBuffer(this->animationLoop->device(), sizeof(ViewportUniforms), wgpu::BufferUsage::Uniform);
 }
 
-Deck::~Deck() {
-  this->animationLoop->stop();
-  // this->tooltip.remove();
-}
+Deck::~Deck() { this->animationLoop->stop(); }
 
 void Deck::setProps(std::shared_ptr<Deck::Props> props) {
-  // this->stats.get('setProps Time').timeStart();
-
   // ViewState tracking
   if (props->initialViewState) {
     if (!props->initialViewState->equals(this->initialViewState)) {
@@ -99,8 +91,6 @@ void Deck::setProps(std::shared_ptr<Deck::Props> props) {
     }
   }
 
-  // Update the animation loop
-
   // Update layerManager
   if (!props->layers.empty()) {
     this->layerManager->setLayersFromProps(props->layers);
@@ -112,34 +102,20 @@ void Deck::setProps(std::shared_ptr<Deck::Props> props) {
   this->viewManager->setViews(props->views);
   this->viewManager->setViewState(this->viewState);
   this->animationLoop->setSize({props->width, props->height});
-
-  // Update manager props
-  // this->effectManager.setProps(resolvedProps);
-  // this->deckRenderer.setProps(resolvedProps);
-  // this->deckPicker.setProps(resolvedProps);
-
-  // super::setProps();
 }
 
 void Deck::run(std::function<void(Deck*)> onAfterRender) {
-  // TODO(ilija@unfolded.ai): We've got a retain cycle here, revisit
-  this->animationLoop->run([&](wgpu::RenderPassEncoder pass) { this->_draw(pass, onAfterRender); });
+  this->animationLoop->run([&](wgpu::RenderPassEncoder pass) { this->_redraw(pass, onAfterRender); });
 }
 
 void Deck::draw(wgpu::TextureView textureView, std::function<void(Deck*)> onAfterRender) {
-  // TODO(ilija@unfolded.ai): We've got a retain cycle here, revisit
-  this->animationLoop->draw(textureView, [&](wgpu::RenderPassEncoder pass) { this->_draw(pass, onAfterRender); });
+  this->animationLoop->draw(textureView,
+                            [&](wgpu::RenderPassEncoder pass) { this->_redraw(pass, onAfterRender, true); });
 }
 
 void Deck::stop() { this->animationLoop->stop(); }
 
-// Public API
-// Check if a redraw is needed
 auto Deck::needsRedraw(bool clearRedrawFlags) -> std::optional<std::string> {
-  // if (this->props->_animate) {
-  //   return "Deck._animate";
-  // }
-
   auto redraw = this->_needsRedraw;
 
   if (clearRedrawFlags) {
@@ -149,8 +125,6 @@ auto Deck::needsRedraw(bool clearRedrawFlags) -> std::optional<std::string> {
   // Query all managers to make sure we clear all flags
   auto viewManagerNeedsRedraw = this->viewManager->getNeedsRedraw(clearRedrawFlags);
   auto layerManagerNeedsRedraw = this->layerManager->needsRedraw(clearRedrawFlags);
-  // auto effectManagerNeedsRedraw = this->effectManager->needsRedraw(opts);
-  // auto deckRendererNeedsRedraw = this->deckRenderer->needsRedraw(opts);
 
   if (viewManagerNeedsRedraw) {
     return viewManagerNeedsRedraw;
@@ -158,61 +132,30 @@ auto Deck::needsRedraw(bool clearRedrawFlags) -> std::optional<std::string> {
   if (layerManagerNeedsRedraw) {
     return layerManagerNeedsRedraw;
   }
+
   return redraw;
 }
 
-void Deck::redraw(bool force) {
-  /*
-  if (!this->layerManager) {
-    // Not yet initialized
-    return;
+auto Deck::_getViewState() -> std::shared_ptr<ViewState> {
+  if (this->props()->viewState) {
+    return this->props()->viewState;
   }
+  return this->viewState;
+}
+
+void Deck::_redraw(wgpu::RenderPassEncoder pass, std::function<void(Deck*)> onAfterRender, bool force) {
   // If force is falsy, check if we need to redraw
-  std::string redrawReason = force || this->needsRedraw(true);
+  std::optional<std::string> redrawReason = force ? "Redraw Forced" : this->needsRedraw(true);
 
   if (!redrawReason) {
     return;
   }
 
-  // this->stats.get('Redraw Count').incrementCount();
-  // if (this->props->_customRender) {
-  //   this->props->_customRender(redrawReason);
-  // } else {
-  this->_drawLayers(redrawReason);
-  // }
-  */
+  this->_drawLayers(pass, onAfterRender, redrawReason.value());
 }
 
-// auto getViews() -> std::list<View*>() { return this->viewManager->views; }
-
-/*
-// Get a set of viewports for a given width and height
-getViewports(rect) {
-  return this->viewManager.getViewports(rect);
-}
-
-// {x, y, radius = 0, layerIds = nullptr, unproject3D}
-pickObject(opts) {
-  const infos = this->_pick('pickObject', 'pickObject Time',
-opts).result; return infos.length ? infos[0] : nullptr;
-}
-
-// {x, y, radius = 0, layerIds = nullptr, unproject3D, depth = 10}
-pickMultipleObjects(opts) {
-  opts.depth = opts.depth || 10;
-  return this->_pick('pickObject', 'pickMultipleObjects Time',
-opts).result;
-}
-
-// {x, y, width = 1, height = 1, layerIds = nullptr}
-pickObjects(opts) {
-  return this->_pick('pickObjects', 'pickObjects Time', opts);
-}
-*/
-
-// Private Methods
-
-void Deck::_draw(wgpu::RenderPassEncoder pass, std::function<void(Deck*)> onAfterRender) {
+void Deck::_drawLayers(wgpu::RenderPassEncoder pass, std::function<void(Deck*)> onAfterRender,
+                       const std::string& redrawReason) {
   this->props()->onBeforeRender(this);
 
   for (auto const& viewport : this->viewManager->getViewports()) {
@@ -224,7 +167,7 @@ void Deck::_draw(wgpu::RenderPassEncoder pass, std::function<void(Deck*)> onAfte
       auto viewportUniforms = getUniformsFromViewport(viewport, this->animationLoop->devicePixelRatio());
 
       this->_viewportUniformsBuffer.SetSubData(0, sizeof(ViewportUniforms), &viewportUniforms);
-      for (auto const& model : layer->getModels()) {
+      for (auto const& model : layer->models()) {
         // Viewport uniforms are currently bound to index 0
         model->setUniformBuffer(0, this->_viewportUniformsBuffer);
       }
@@ -236,413 +179,3 @@ void Deck::_draw(wgpu::RenderPassEncoder pass, std::function<void(Deck*)> onAfte
   onAfterRender(this);
   this->props()->onAfterRender(this);
 }
-
-// Get the most relevant view state: props->viewState, if supplied,
-// shadows internal viewState
-// TODO(ib@unfolded.ai): For backwards compatibility ensure numeric width and height is
-// added to the viewState
-// auto _getViewState() -> ViewState* { return this->props->viewState || this->viewState; }
-
-// Get the view descriptor list
-/*
-_getViews() {
-// Default to a full screen map view port
-let views = this->props->views || new std::list<View*>(new MapView('default-view'));
-views = Array.isArray(views) ? views : [views];
-if (views.length && this->props->controller) {
-  // Backward compatibility: support controller prop
-  views[0].props->controller = this->props->controller;
-}
-return views;
-}
-*/
-
-/*
-void Deck::_pick(method, statKey, opts) {
-  const {stats} = this;
-
-  stats.get('Pick Count').incrementCount();
-  stats.get(statKey).timeStart();
-
-  const infos = this->deckPicker[method](
-    Object.assign(
-      {
-        layers: this->layerManager.getLayers(opts),
-        viewports: this->getViewports(opts),
-        onViewportActive: this->layerManager.activateViewport
-      },
-      opts
-    )
-  );
-
-  stats.get(statKey).timeEnd();
-
-  return infos;
-}
-
-  // canvas, either string, canvas or `nullptr`
-void Deck::_createCanvas(props) {
-  let canvas = props->canvas;
-
-  // TODO EventManager should accept element id
-  if (typeof canvas === 'string') {
-    canvas = document.getElementById(canvas);
-    assert(canvas);
-  }
-
-  if (!canvas) {
-    canvas = document.createElement('canvas');
-    const parent = props->parent || document.body;
-    parent.appendChild(canvas);
-  }
-
-  const {id, style} = props;
-  canvas.id = id;
-  Object.assign(canvas.style, style);
-
-  return canvas;
-}
-
-// Updates canvas width and/or height, if provided as props
-void Deck::_setCanvasSize(props) {
-  if (!this->canvas) {
-    return;
-  }
-
-  let {width, height} = props;
-  // Set size ONLY if props are being provided, otherwise let canvas be
-layouted freely if (width || width === 0) { width =
-Number.isFinite(width) ? `${width}px` : width; this->canvas.style.width
-= width;
-  }
-  if (height || height === 0) {
-    height = Number.isFinite(height) ? `${height}px` : height;
-    // Note: position==='absolute' required for height 100% to work
-    this->canvas.style.position = 'absolute';
-    this->canvas.style.height = height;
-  }
-}
-
-// If canvas size has changed, updates
-Deck::_updateCanvasSize() {
-  if (this->_checkForCanvasSizeChange()) {
-    const {width, height} = this;
-    this->viewManager.setProps({width, height});
-    this->props->onResize({width: this->width, height: this->height});
-  }
-}
-
-  // If canvas size has changed, reads out the new size and returns true
-void Deck::_checkForCanvasSizeChange() {
-  const {canvas} = this;
-  if (!canvas) {
-    return false;
-  }
-  // Fallback to width/height when clientWidth/clientHeight are 0 or
-undefined. const newWidth = canvas.clientWidth || canvas.width; const
-newHeight = canvas.clientHeight || canvas.height; if (newWidth !==
-this->width || newHeight !== this->height) { this->width = newWidth;
-    this->height = newHeight;
-    return true;
-  }
-  return false;
-}
-
-// The `pointermove` event may fire multiple times in between two animation frames,
-// it's a waste of time to run picking without rerender. Instead we save the last pick
-// request and only do it once on the next animation frame.
-void Deck::_onPointerMove(event) {
-  const {_pickRequest} = this;
-  if (event.type === 'pointerleave') {
-    _pickRequest.x = -1;
-    _pickRequest.y = -1;
-    _pickRequest.radius = 0;
-  } else if (event.leftButton || event.rightButton) {
-    // Do not trigger onHover callbacks if mouse button is down.
-    return;
-  } else {
-    const pos = event.offsetCenter;
-    // Do not trigger callbacks when click/hover position is invalid. Doing so will cause a
-    // assertion error when attempting to unproject the position.
-    if (!pos) {
-      return;
-    }
-    _pickRequest.x = pos.x;
-    _pickRequest.y = pos.y;
-    _pickRequest.radius = this->props->pickingRadius;
-  }
-
-  if (this->layerManager) {
-    this->layerManager.context.mousePosition = {x: _pickRequest.x, y: _pickRequest.y};
-  }
-
-  _pickRequest.event = event;
-  _pickRequest.mode = 'hover';
-}
-
-// Actually run picking
-void Deck::_pickAndCallback() {
-    const {_pickRequest} = this;
-
-    if (_pickRequest.event) {
-      // Perform picking
-      const {result, emptyInfo} = this->_pick('pickObject', 'pickObject
-  Time', _pickRequest); const pickedInfo = result[0] || emptyInfo;
-
-      // Update tooltip
-      if (this->props->getTooltip) {
-        const displayInfo = this->props->getTooltip(pickedInfo);
-        this->tooltip.setTooltip(displayInfo, pickedInfo.x, pickedInfo.y);
-      }
-
-      // Execute callbacks
-      let handled = false;
-      if (pickedInfo.layer) {
-        handled = pickedInfo.layer.onHover(pickedInfo,
-  _pickRequest.event);
-      }
-      if (!handled && this->props->onHover) {
-        this->props->onHover(pickedInfo, _pickRequest.event);
-      }
-
-      // Clear pending pickRequest
-      _pickRequest.event = nullptr;
-    }
-  }
-
-void Deck::_updateCursor() {
-  // const container = this->props->parent || this->canvas;
-  // if (container) {
-  //   container.style.cursor = this->props->getCursor(this->interactiveState);
-  // }
-}
-
-void Deck::_setGLContext(gl) {
-  if (this->layerManager) {
-    return;
-  }
-
-  // if external context...
-  if (!this->canvas) {
-    this->canvas = gl.canvas;
-    instrumentGLContext(gl, {enable: true, copyState: true});
-  }
-
-  this->tooltip = new Tooltip(this->canvas);
-
-  setParameters(gl, {
-    blend: true,
-    blendFunc: [GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA, GL.ONE, GL.ONE_MINUS_SRC_ALPHA], polygonOffsetFill: true,
-depthTest: true, depthFunc: GL.LEQUAL
-  });
-
-  this->props->onWebGLInitialized(gl);
-
-  // timeline for transitions
-  const timeline = new Timeline();
-  timeline.play();
-  this->animationLoop.attachTimeline(timeline);
-
-  this->eventManager = new EventManager(this->props->parent || gl.canvas,
-  { touchAction: this->props->touchAction, events: { pointerdown:
-  this->_onPointerDown, pointermove: this->_onPointerMove, pointerleave:
-  this->_onPointerMove
-    }
-    });
-    for (const eventType in EVENTS) {
-      this->eventManager.on(eventType, this->_onEvent);
-    }
-
-  this->viewManager = new ViewManager({
-    timeline,
-    eventManager: this->eventManager,
-    onViewStateChange: this->_onViewStateChange,
-    onInteractiveStateChange: this->_onInteractiveStateChange,
-    views: this->_getViews(),
-    viewState: this->_getViewState(),
-    width: this->width,
-    height: this->height
-  });
-
-  // viewManager must be initialized before layerManager
-  // layerManager depends on viewport created by viewManager.
-  const viewport = this->viewManager.getViewports()[0];
-
-  // Note: avoid React setState due GL animation loop / setState timing
-issue this->layerManager = new LayerManager(gl, { deck: this, stats:
-this->stats, viewport, timeline
-  });
-
-  this->effectManager = new EffectManager();
-
-  this->deckRenderer = new DeckRenderer(gl);
-
-  this->deckPicker = new DeckPicker(gl);
-
-  this->setProps(this->props);
-
-  this->_updateCanvasSize();
-  this->props->onLoad();
-*/
-
-/*
-void Deck::_drawLayers() {  // redrawReason, renderOptions) {
-  const gl = this->layerManager.context.gl;
-
-  // setParameters(gl, this->props->parameters);
-
-  this->props->onBeforeRender(gl);
-
-  this->deckRenderer.renderLayers(this->props->_framebuffer, this->layerManager.getLayers(),
-                                  this->viewManager.getViewports(), this->layerManager.activateViewport,
-                                  this->viewManager.getViews(), 'screen', redrawReason
-                                  // this->effectManager.getEffects()
-  );
-
-  this->props->onAfterRender(gl);
-}
-*/
-// Callbacks
-/*
-
-void Deck::_onRendererInitialized(void* gl) { this->_setGLContext(gl); }
-
-void Deck::_onRenderFrame(void* animationProps) {
-  // this->_getFrameStats();
-
-  // // Log perf stats every second
-  // if (this->_metricsCounter++ % 60 === 0) {
-  //   this->_getMetrics();
-  //   this->stats.reset();
-  //   log.table(4, this->metrics)();
-
-  //   // Experimental: report metrics
-  //   if (this->props->_onMetrics) {
-  //     this->props->_onMetrics(this->metrics);
-  //   }
-  // }
-
-  this->_updateCanvasSize();
-
-  this->_updateCursor();
-
-  // Update layers if needed (e.g. some async prop has loaded)
-  // Note: This can trigger a redraw
-  this->layerManager.updateLayers();
-
-  // Perform picking request if any
-  this->_pickAndCallback();
-
-  // Redraw if necessary
-  this->redraw(false);
-
-  // Update viewport transition if needed
-  // Note: this can trigger `onViewStateChange`, and affect layers
-  // We want to defer these changes to the next frame
-  if (this->viewManager) {
-    this->viewManager.updateViewStates();
-  }
-}
-*/
-
-// Callbacks
-
-/*
-void Deck::_onViewStateChange(params) {
-  // Let app know that view state is changing, and give it a chance to
-  // change it
-  const viewState = this->props->onViewStateChange(params) || params.viewState;
-
-  // If initialViewState was set on creation, auto track position
-  if (this->viewState) {
-    this->viewState = {... this->viewState, [params.viewId] : viewState};
-    if (!this->props->viewState) {
-      // Apply internal view state
-      this->viewManager.setProps({viewState : this->viewState});
-    }
-  }
-}
-
-void Deck::_onInteractiveStateChange(bool isDragging) {
-  // this->interactiveState.isDragging = isDragging;
-}
-
-void Deck::_onEvent(void* event) {
-  // const eventOptions = EVENTS[event.type];
-  // const pos = event.offsetCenter;
-
-  // if (!eventOptions || !pos) {
-  //   return;
-  // }
-
-  // // Reuse last picked object
-  // const layers = this->layerManager.getLayers();
-  // const info = this->deckPicker.getLastPickedObject(
-  //   {
-  //     x: pos.x,
-  //     y: pos.y,
-  //     layers,
-  //     viewports: this->getViewports(pos)
-  //   },
-  //   this->_lastPointerDownInfo
-  // );
-
-  // const {layer} = info;
-  // const layerHandler =
-  //   layer && (layer[eventOptions.handler] ||
-  // layer.props[eventOptions.handler]); const rootHandler =
-  // this->props[eventOptions.handler]; let handled = false;
-
-  // if (layerHandler) {
-  //   handled = layerHandler.call(layer, info, event);
-  // }
-  // if (!handled && rootHandler) {
-  //   rootHandler(info, event);
-  // }
-}
-
-void Deck::_onPointerDown(event) {
-  // const pos = event.offsetCenter;
-  // this->_lastPointerDownInfo = this->pickObject({
-  //   x: pos.x,
-  //   y: pos.y,
-  //   radius: this->props->pickingRadius
-  // });
-}
-
-void Deck::_getFrameStats() {
-  // const {stats} = this;
-  // stats.get('frameRate').timeEnd();
-  // stats.get('frameRate').timeStart();
-
-  // // Get individual stats from luma.gl so reset works
-  // const animationLoopStats = this->animationLoop.stats;
-  // stats.get('GPU Time').addTime(animationLoopStats.get('GPUTime').lastTiming); stats.get('CPU
-  // Time').addTime(animationLoopStats.get('CPU Time').lastTiming);
-}
-
-void Deck::_getMetrics() {
-  // const {metrics, stats} = this;
-  // metrics.fps = stats.get('frameRate').getHz();
-  // metrics.setPropsTime = stats.get('setProps Time').time;
-  // metrics.updateAttributesTime = stats.get('Update Attributes').time;
-  // metrics.framesRedrawn = stats.get('Redraw Count').count;
-  // metrics.pickTime =
-  //   stats.get('pickObject Time').time +
-  //   stats.get('pickMultipleObjects Time').time +
-  //   stats.get('pickObjects Time').time;
-  // metrics.pickCount = stats.get('Pick Count').count;
-
-  // // Luma stats
-  // metrics.gpuTime = stats.get('GPU Time').time;
-  // metrics.cpuTime = stats.get('CPU Time').time;
-  // metrics.gpuTimePerFrame = stats.get('GPU Time').getAverageTime();
-  // metrics.cpuTimePerFrame = stats.get('CPU Time').getAverageTime();
-
-  // const memoryStats = lumaStats.get('Memory Usage');
-  // metrics.bufferMemory = memoryStats.get('Buffer Memory').count;
-  // metrics.textureMemory = memoryStats.get('Texture Memory').count;
-  // metrics.renderbufferMemory = memoryStats.get('Renderbuffer
-  // Memory').count; metrics.gpuMemory = memoryStats.get('GPU Memory').count;
-}
-*/

--- a/cpp/modules/deck.gl/core/src/lib/layer-context.h
+++ b/cpp/modules/deck.gl/core/src/lib/layer-context.h
@@ -32,7 +32,7 @@ class Deck;
 class LayerManager;
 class Viewport;
 
-// LayerContext is data shared between all layers
+/// \brief LayerContext is data shared between all layers.
 class LayerContext {
  public:
   // TODO(ilija@unfolded.ai): Do we need to have this circular dependency here?
@@ -44,14 +44,6 @@ class LayerContext {
   std::shared_ptr<LayerManager> layerManager;
   // Make sure context.viewport is not empty on the first layer initialization
   std::shared_ptr<Viewport> viewport{new WebMercatorViewport{{}}};
-
-  // // General resources
-  // stats: null, // for tracking lifecycle performance
-  // // GL Resources
-  // shaderCache: null,
-  // pickingFBO: null, // Screen-size framebuffer that layers can reuse
-  // mousePosition: null,
-  // userData: {} // Place for any custom app `context`
 
   LayerContext(Deck* deck, wgpu::Device device, float devicePixelRatio = 1.0)
       : deck{deck}, device{device}, devicePixelRatio{devicePixelRatio} {}

--- a/cpp/modules/deck.gl/core/src/lib/layer-manager.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/layer-manager.cpp
@@ -93,7 +93,7 @@ void LayerManager::setLayersFromProps(const std::list<std::shared_ptr<Layer::Pro
       oldLayerMap.erase(matchedLayerIterator);
     } else {
       // TODO(ib@unfolded.ai): Handle exceptions
-      this->addLayer(std::static_pointer_cast<Layer>(layerProps->makeComponent(layerProps)));
+      this->addLayer(std::dynamic_pointer_cast<Layer>(layerProps->makeComponent(layerProps)));
     }
   }
 

--- a/cpp/modules/deck.gl/core/src/lib/layer-manager.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/layer-manager.cpp
@@ -29,17 +29,12 @@
 
 using namespace deckgl;
 
-LayerManager::LayerManager(
-    std::shared_ptr<LayerContext> _context)  // (gl, {deck, stats, viewport = null, timeline = null} = {}) {
-    : context{_context}                      // gl,
-{
-  // this->_needsRedraw = 'Initial render';
-  // this->_needsUpdate = false;
-  // this->_debug = false;
-  // this->_onError = null;
+LayerManager::LayerManager(std::shared_ptr<LayerContext> _context) : context{_context} {
+  this->_needsRedraw = "Initial render";
+  this->_needsUpdate = std::nullopt;
+  this->_debug = false;
 }
 
-// Method to call when the layer manager is not needed anymore.
 LayerManager::~LayerManager() {
   // Finalize all layers
   for (auto layer : this->layers) {
@@ -47,60 +42,43 @@ LayerManager::~LayerManager() {
   }
 }
 
-// Check if a redraw is needed
 auto LayerManager::needsRedraw(bool clearRedrawFlags) -> std::optional<std::string> {
-  return "TODO: redraw checking not implemented, so we always redraw";
-
-  /*
   auto redraw = this->_needsRedraw;
   if (clearRedrawFlags) {
-    this->_needsRedraw = "";
+    this->_needsRedraw = std::nullopt;
   }
 
-  // This layers list doesn't include sublayers, relying on composite
-  // layers
+  if (redraw) {
+    return redraw;
+  }
+
   for (auto layer : this->layers) {
     // Call every layer to clear their flags
-    auto layerNeedsRedraw = layer->getNeedsRedraw(clearRedrawFlags);
-    // redraw = redraw || layerNeedsRedraw;
+    if (auto layerNeedsRedraw = layer->getNeedsRedraw(clearRedrawFlags)) {
+      return layerNeedsRedraw;
+    }
   }
 
-  return redraw;
-  */
+  return std::nullopt;
 }
 
-// Check if a deep update of all layers is needed
-// auto LayerManager::needsUpdate() -> std::string { return this->_needsUpdate; }
-
-// Layers will be redrawn (in next animation frame)
 void LayerManager::setNeedsRedraw(const std::string &reason) {
   if (this->_needsRedraw) {
     this->_needsRedraw = reason;
   }
 }
 
-// Layers will be updated deeply (in next animation frame)
-// Potentially regenerating attributes and sub layers
 void LayerManager::setNeedsUpdate(const std::string &reason) {
   if (!this->_needsUpdate) {
     this->_needsUpdate = reason;
   }
 }
 
-// Props
-
-void LayerManager::setDebug(bool debug) {}
-void LayerManager::setUserData(void *userData) {}
-void LayerManager::setOnError() {}
-
-// Layer API
-
-// For JSON: Supply a new layer prop list, match against existing layers
 void LayerManager::setLayersFromProps(const std::list<std::shared_ptr<Layer::Props>> &layerPropsList) {
   // Create a map of old layers
-  std::map<std::string, Layer *> oldLayerMap;
+  std::map<std::string, std::shared_ptr<Layer>> oldLayerMap;
   for (auto oldLayer : this->layers) {
-    oldLayerMap[oldLayer->props()->id] = oldLayer.get();
+    oldLayerMap[oldLayer->props()->id] = oldLayer;
   }
 
   // Update old layers or add new layers if not matched
@@ -109,19 +87,19 @@ void LayerManager::setLayersFromProps(const std::list<std::shared_ptr<Layer::Pro
     auto matchedLayerIterator = oldLayerMap.find(layerProps->id);
     if (matchedLayerIterator != oldLayerMap.end()) {
       // If a layer with this id is present, set the props
-      // TODO(ib@unfolded.ai): catch exceptions and continue
+      // TODO(ib@unfolded.ai): Catch exceptions and continue
       auto matchedLayer = matchedLayerIterator->second;
       matchedLayer->setProps(layerProps);
       oldLayerMap.erase(matchedLayerIterator);
     } else {
-      // TODO(ib@unfolded.ai): handle exceptions
-      this->addLayer(std::shared_ptr<Layer>{layerProps->makeComponent(layerProps)});
+      // TODO(ib@unfolded.ai): Handle exceptions
+      this->addLayer(std::static_pointer_cast<Layer>(layerProps->makeComponent(layerProps)));
     }
   }
 
   // Remove any unmatched layers
   for (const auto &unmatchedLayerId : oldLayerMap | ranges::views::keys) {
-    // TODO(ib@unfolded.ai): handle exceptions
+    // TODO(ib@unfolded.ai): Handle exceptions
     this->removeLayer(unmatchedLayerId);
   }
 }
@@ -146,107 +124,13 @@ void LayerManager::removeLayer(const std::string &id) {
   this->layers.remove_if([id](auto layer) { return layer->props()->id == id; });
 }
 
-/*
-// Gets an (optionally) filtered list of layers
-// auto LayerManager::getLayers(const std::list<std::string> &layerIds = std::list<std::string>{})
-//     -> std::list<std::shared_ptr<Layer>>;
-
-// auto LayerManager::findLayerById(const std::string &id) -> std::shared_ptr<Layer>;
-
-void LayerManager::removeAllLayers() {
-  // TODO(ib) - exception handling
-  for (auto layer : this->layers) {
-    layer->finalize();
-  }
-  this->layers.clear();
-}
-*/
-
-// Update layers from last cycle if `setNeedsUpdate()` has been called
 void LayerManager::updateLayers() {
   for (auto layer : this->layers) {
-    // TODO(ib@unfolded.ai): handle exceptions
+    // TODO(ib@unfolded.ai): Handle exceptions
     layer->update();
   }
 }
 
-// Gets an (optionally) filtered list of layers
-/*
-auto LayerManager::getLayers() -> std::list<Layer *> {
-  // Filtering by layerId compares beginning of strings, so that sublayers
-  // will be included Dependes on the convention of adding suffixes to the
-  // parent's layer name
-  // return layerIds ? this->layers.filter(layer = > layerIds.find(layerId = > layer->id.indexOf(layerId) == = 0))
-  //                 : this->layers;
-  return this->layers;
-}
-*/
-
-// Set props needed for layer rendering and picking.
-/*
-LayerManager::setProps(props) {
-  if ('debug' in props) {
-    this->_debug = props.debug;
-  }
-
-  // A way for apps to add data to context that can be accessed in layers
-  if ('userData' in props) {
-    this->context.userData = props.userData;
-  }
-
-  // TODO(ib@unfolded.ai): - For now we set layers before viewports to preserve changeFlags
-  if ('layers' in props) {
-    this->setLayers(props.layers);
-  }
-
-  if ('onError' in props) {
-    this->_onError = props.onError;
-  }
-}
-*/
-
-// Supply a new layer list, initiating sublayer generation and layer
-// matching
-/*
-void LayerManager::setLayers(std::list<Layer *> newLayers, bool forceUpdate) {
-  // TODO(ib@unfolded.ai): - something is generating state updates that cause rerender of
-  // the same
-  const shouldUpdate = forceUpdate || newLayers != = this->lastRenderedLayers;
-  // debug(TRACE_SET_LAYERS, this, shouldUpdate, newLayers);
-
-  if (!shouldUpdate) {
-    return;
-  }
-  this->lastRenderedLayers = newLayers;
-
-  // TODO(ib@unfolded.ai): array flattening needs to be done during JSON conversion?
-  // newLayers = flatten(newLayers, {filter : Boolean});
-
-  for (auto layer : newLayers) {
-    layer->context = this->context;
-  }
-
-  this->_updateLayers(this->layers, newLayers);
-}
-*/
-
-// Update layers from last cycle if `setNeedsUpdate()` has been called
-/*
-void LayerManager::updateLayers() {
-  // NOTE: For now, even if only some layer has changed, we update all
-  // layers to ensure that layer id maps etc remain consistent even if
-  // different sublayers are rendered
-  auto reason = this->needsUpdate();
-  if (reason) {
-    this->setNeedsRedraw("updating layers : $ { reason }");  // TODO(ib@unfolded.ai): string
-    // Force a full update
-    auto forceUpdate = true;
-    this->setLayers(this->lastRenderedLayers, forceUpdate);
-  }
-}
-*/
-
-// Make a viewport "current" in layer context, updating viewportChanged flags.
 void LayerManager::activateViewport(const std::shared_ptr<Viewport> &viewport) {
   auto oldViewport = this->context->viewport;
   auto viewportChanged = !oldViewport || oldViewport != viewport;
@@ -263,10 +147,6 @@ void LayerManager::activateViewport(const std::shared_ptr<Viewport> &viewport) {
   }
 }
 
-//
-// PRIVATE METHODS
-//
-
 void LayerManager::_updateLayer(const std::shared_ptr<Layer> &layer) {
   try {
     layer->update();
@@ -274,108 +154,3 @@ void LayerManager::_updateLayer(const std::shared_ptr<Layer> &layer) {
     probegl::ErrorLog() << "Layer update failed with: " << ex.what();
   }
 }
-
-// void LayerManager::_handleError(stage, error, layer) {
-//   if (this->_onError) {
-//     this->_onError(error, layer);
-//   } else {
-//     log.error(`error during ${stage} of $ { layerName(layer) }`, error)();
-//   }
-// }
-
-// Match all layers, checking for caught errors
-// To avoid having an exception in one layer disrupt other layers
-// TODO(ib@unfolded.ai): - mark layers with exceptions as bad and remove from rendering
-// cycle?
-/*
-void LayerManager::_updateLayers(oldLayers, newLayers) {
-// Create old layer map
-std::map<std::string, Layer *> oldLayerMap;
-for (const oldLayer : oldLayers) {
-  if (oldLayerMap[oldLayer.id]) {
-    log.warn(`Multiple old layers with same id $ { layerName(oldLayer) }`)();
-  } else {
-    oldLayerMap[oldLayer.id] = oldLayer;
-  }
-}
-
-// Allocate array for generated layers
-const generatedLayers = [];
-
-// Match sublayers
-this->_updateSublayersRecursively(newLayers, oldLayerMap, generatedLayers);
-
-// Finalize unmatched layers
-this->_finalizeOldLayers(oldLayerMap);
-
-let needsUpdate = false;
-for (auto layer : generatedLayers) {
-  if (layer->hasUniformTransition()) {
-    needsUpdate = true;
-    break;
-  }
-}
-
-this->_needsUpdate = needsUpdate;
-this->layers = generatedLayers;
-}
-*/
-
-// Note: adds generated layers to `generatedLayers` array parameter
-/*
-void LayerManager::_updateSublayersRecursively(newLayers, oldLayerMap, generatedLayers) {
-  for (const newLayer of newLayers) {
-    newLayer.context = this->context;
-
-    // Given a new coming layer, find its matching old layer (if any)
-    const oldLayer = oldLayerMap[newLayer.id];
-    if (oldLayer == = null) {
-      // null, rather than undefined, means this id was originally
-      // there
-      log.warn(`Multiple new layers with same id $ { layerName(newLayer) }`)();
-    }
-    // Remove the old layer from candidates, as it has been matched with
-    // this layer
-    oldLayerMap[newLayer.id] = null;
-
-    let sublayers = null;
-
-    // We must not generate exceptions until after layer matching is
-    // complete
-    try {
-      if (this->_debug &&oldLayer != = newLayer) {
-        newLayer.validateProps();
-      }
-
-      if (!oldLayer) {
-        this->_initializeLayer(newLayer);
-      } else {
-        this->_transferLayerState(oldLayer, newLayer);
-        this->_updateLayer(newLayer);
-      }
-      generatedLayers.push(newLayer);
-
-      sublayers = newLayer.isComposite && newLayer.getSubLayers();
-      catch (err) {
-      this->_handleError('matching', err,
-                         newLayer);  // Record first exception
-    }
-
-    if (sublayers) {
-      this->_updateSublayersRecursively(sublayers, oldLayerMap, generatedLayers);
-    }
-  }
-}
-*/
-
-// Finalize any old layers that were not matched
-/*
-void LayerManager::_finalizeOldLayers(oldLayerMap) {
-  // for (const layerId in oldLayerMap) {
-  //   const layer = oldLayerMap[layerId];
-  //   if (layer) {
-  //     this->_finalizeLayer(layer);
-  //   }
-  // }
-}
-*/

--- a/cpp/modules/deck.gl/core/src/lib/layer-manager.h
+++ b/cpp/modules/deck.gl/core/src/lib/layer-manager.h
@@ -38,76 +38,42 @@ class LayerManager {
 
   std::list<std::shared_ptr<Layer>> layers;
 
-  std::optional<std::string> _needsRedraw;
-  std::optional<std::string> _needsUpdate;
-  bool _debug;
-
   explicit LayerManager(std::shared_ptr<LayerContext> context);
   virtual ~LayerManager();
 
-  // Check if a redraw is needed
+  /// \brief Check if a redraw is needed.
   auto needsRedraw(bool clearRedrawFlags = false) -> std::optional<std::string>;
-  // Check if a deep update of layers is needed
-  auto needsUpdate() -> std::optional<std::string>;
-  // Ensures that layers will be redrawn (during next render)
-  void setNeedsRedraw(const std::string &reason);
-  // Ensiure that layers will be updated deeply (during next render), including sublayer generation
-  void setNeedsUpdate(const std::string &reason);
+  /// \brief Check if a deep update of layers is needed.
+  auto needsUpdate() -> std::optional<std::string> { return this->_needsUpdate; };
+  /// \brief Ensures that layers will be redrawn (during next render).
+  void setNeedsRedraw(const std::string& reason);
+  /// \brief Ensure that layers will be updated deeply (during next render), including sublayer generation.
+  void setNeedsUpdate(const std::string& reason);
 
-  // Props
+  void setDebug(bool debug) { this->_debug = debug; }
 
-  void setDebug(bool debug);
-  void setUserData(void *userData);
-  void setOnError();
+  /* Layer API */
 
-  // Layer API
-
-  // For JSON: Supply a new layer prop list
-  void setLayersFromProps(const std::list<std::shared_ptr<Layer::Props>> &newLayers);
+  /// \brief For JSON: Supply a new layer prop list.
+  void setLayersFromProps(const std::list<std::shared_ptr<Layer::Props>>& newLayers);
 
   void addLayer(std::shared_ptr<Layer>);
   void removeLayer(std::shared_ptr<Layer>);
-  void removeLayer(const std::string &id);
+  void removeLayer(const std::string& id);
 
-  // Gets an (optionally) filtered list of layers
-  // auto getLayers(const std::list<std::string> &layerIds = std::list<std::string>{})
-  //     -> std::list<std::shared_ptr<Layer>>;
-  // auto findLayerById(const std::string &id) -> std::shared_ptr<Layer>;
-  // void removeAllLayers();
-  // void removeLayerById(const std::string &id);
-
-  // Update layers from last cycle if `setNeedsUpdate()` has been called
+  /// \brief Update layers from last cycle if `setNeedsUpdate()` has been called.
   void updateLayers();
 
-  // Make a viewport "current" in layer context, updating viewportChanged flags
-  void activateViewport(const std::shared_ptr<Viewport> &viewport);
+  /// \brief Make a viewport "current" in layer context, updating viewportChanged flags.
+  void activateViewport(const std::shared_ptr<Viewport>& viewport);
 
-  //
-  // PRIVATE METHODS
-  //
+ private:
+  /// \brief Updates a single layer, cleaning all flags.
+  void _updateLayer(const std::shared_ptr<Layer>& layer);
 
-  // void _handleError(stage, error, layer);
-
-  // Match all layers, checking for caught errors
-  // To avoid having an exception in one layer disrupt other layers
-  // TODO(ib) - mark layers with exceptions as bad and remove from rendering cycle?
-  void _updateLayers(const std::list<Layer> &oldLayers, const std::list<Layer::Props> &newLayers);
-
-  // Finalize any old layers that were not matched
-  void _finalizeOldLayers(const std::map<std::string, Layer *> &oldLayerMap);
-
-  // EXCEPTION SAFE LAYER ACCESS
-
-  // Initializes a single layer, calling layer methods
-  void _initializeLayer(Layer *);
-
-  // void _transferLayerState(Layer *oldLayer, Layer *newLayer);
-
-  // Updates a single layer, cleaning all flags
-  void _updateLayer(const std::shared_ptr<Layer> &layer);
-
-  // Finalizes a single layer
-  void _finalizeLayer(Layer *);
+  std::optional<std::string> _needsRedraw;
+  std::optional<std::string> _needsUpdate;
+  bool _debug;
 };
 
 }  // namespace deckgl

--- a/cpp/modules/deck.gl/core/src/lib/layer-state.h
+++ b/cpp/modules/deck.gl/core/src/lib/layer-state.h
@@ -28,7 +28,7 @@ namespace deckgl {
 class Layer;
 class AttributeManager;
 
-class LayerState {  // }: public ComponentState {
+class LayerState {
  public:
   LayerState(const std::shared_ptr<Layer>& layer, const std::shared_ptr<AttributeManager>& attributeManager)
       : layer{layer}, attributeManager{attributeManager}, needsRedraw{true} {}

--- a/cpp/modules/deck.gl/core/src/lib/layer-state.h
+++ b/cpp/modules/deck.gl/core/src/lib/layer-state.h
@@ -21,6 +21,8 @@
 #ifndef DECKGL_CORE_LAYER_STATE_H
 #define DECKGL_CORE_LAYER_STATE_H
 
+#include <memory>
+
 namespace deckgl {
 
 class Layer;
@@ -28,22 +30,12 @@ class AttributeManager;
 
 class LayerState {  // }: public ComponentState {
  public:
-  Layer* layer;
-  AttributeManager* attributeManager;
+  LayerState(const std::shared_ptr<Layer>& layer, const std::shared_ptr<AttributeManager>& attributeManager)
+      : layer{layer}, attributeManager{attributeManager}, needsRedraw{true} {}
+
+  std::shared_ptr<Layer> layer;
+  std::shared_ptr<AttributeManager> attributeManager;
   bool needsRedraw;
-
-  LayerState(Layer* layer_, AttributeManager* attributeManager_) {
-    this->layer = layer_;
-    this->attributeManager = attributeManager_;
-    this->needsRedraw = true;
-    // this->model = null;
-    // this->subLayers = null; // reference to sublayers rendered in a
-    // previous cycle
-  }
-
-  get layer() { return this->layer; }
-
-  set layer(layer) { this->layer = layer; }
 }
 
 }  // namespace deckgl

--- a/cpp/modules/deck.gl/core/src/lib/layer.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/layer.cpp
@@ -27,14 +27,10 @@ using namespace deckgl;
 
 // Setters and getters for properties
 // TODO(ib@unfolded.ai): auto generate from language-independent prop definition schema
-
 static const std::vector<const Property*> propTypeDefs = {
     new PropertyT<bool>{
         "visible", [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->visible; },
         [](JSONObject* props, bool value) { return dynamic_cast<Layer::Props*>(props)->visible = value; }, true},
-    new PropertyT<bool>{
-        "pickable", [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->pickable; },
-        [](JSONObject* props, bool value) { return dynamic_cast<Layer::Props*>(props)->pickable = value; }, false},
     new PropertyT<float>{
         "opacity", [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->opacity; },
         [](JSONObject* props, float value) { return dynamic_cast<Layer::Props*>(props)->opacity = value; }, 1.0},
@@ -69,99 +65,30 @@ auto Layer::Props::getProperties() const -> const Properties* {
   return &properties;
 }
 
-/*
-class LayerProperties {
-  // data: Special handling for null, see below
-  // data: {type: 'data', value: EMPTY_ARRAY, async: true},
-  // dataComparator: null,
-  // _dataDiff: {type: 'function', value: data => data && data.__diff, compare: false, optional: true},
-  // dataTransform: {type: 'function', value: null, compare: false, optional: true},
-  // onDataLoad: {type: 'function', value: null, compare: false, optional: true},
-  // fetch: {
-  //   type: 'function',
-  //   value: (url, {layer}) => load(url, layer.getLoadOptions()),
-  //   compare: false
-  // },
-  // updateTriggers: {}, // Update triggers: a core change detection mechanism in deck.gl
-
-  opacity: {type: 'number', min: 0, max: 1, value: 1},
-
-  onHover: {type: 'function', value: null, compare: false, optional: true},
-  onClick: {type: 'function', value: null, compare: false, optional: true},
-  onDragStart: {type: 'function', value: null, compare: false, optional: true},
-  onDrag: {type: 'function', value: null, compare: false, optional: true},
-  onDragEnd: {type: 'function', value: null, compare: false, optional: true},
-
-  coordinateSystem: COORDINATE_SYSTEM.DEFAULT,
-  coordinateOrigin: {type: 'array', value: [0, 0, 0], compare: true},
-  modelMatrix: {type: 'array', value: null, compare: true, optional: true},
-  wrapLongitude: false,
-  positionFormat: 'XYZ',
-  colorFormat: 'RGBA',
-
-  parameters: {},
-  uniforms: {},
-  extensions: [],
-
-  // Offset depth based on layer index to avoid z-fighting.
-  // Negative values pull layer towards the camera
-  // https://www.opengl.org/archives/resources/faq/technical/polygonoffset.htm
-  getPolygonOffset: {
-    type: 'function',
-    value: ({layerIndex}) => [0, -layerIndex * 100],
-    compare: false
-  },
-
-  // Selection/Highlighting
-  highlightedObjectIndex: null,
-  autoHighlight: false,
-  highlightColor: {type: 'color', value: [0, 0, 128, 128]}
-};
-*/
-
-// auto toString() {
-//   const className = this->constructor.layerName ||
-//   this->constructor.name; return `${className}({id:
-//   "${this->props.id}"})`;
-// }
-
-// Public API
-
-// Updates selected state members and marks the object for redraw
-// auto setState(updateObject) -> void {
-//   this->setChangeFlags({stateChanged: true});
-//   Object.assign(this->state, updateObject);
-//   this->setNeedsRedraw();
-// }
-
 void Layer::setProps(std::shared_ptr<Layer::Props> newProps) {
-  // this->props = newProps;
+  this->_props = newProps;
   this->setNeedsUpdate("Props updated");
   this->setNeedsRedraw("Props updated");
 }
 
 void Layer::triggerUpdate(const std::string& gpuColumnName) {
-  this->attributeManager->invalidate(gpuColumnName);
+  this->_attributeManager->invalidate(gpuColumnName);
   this->setNeedsUpdate(gpuColumnName);
 }
 
-// Sets the redraw flag for this layer, will trigger a redraw next animation frame
 void Layer::setNeedsRedraw(const std::string& reason) { this->needsRedraw = reason; }
 
-// This layer needs a deep update
 void Layer::setNeedsUpdate(const std::string& reason) {
   this->context->layerManager->setNeedsUpdate(reason);
   this->needsUpdate = reason;
 }
 
-// Checks state of attributes and model
 auto Layer::getNeedsRedraw(bool clearRedrawFlags) -> std::optional<std::string> {
-  return "not implemented";  // this->_getNeedsRedraw(clearRedrawFlags);
+  return "TODO: Layers always need to be redrawn";  // this->_getNeedsRedraw(clearRedrawFlags);
 }
 
-// Checks if layer attributes needs updating
 auto Layer::getNeedsUpdate() -> std::optional<std::string> {
-  return "not implemented";
+  return "Not implemented";
   //   // Call subclass lifecycle method
   //   return (
   //     this->internalState->needsUpdate ||
@@ -171,138 +98,13 @@ auto Layer::getNeedsUpdate() -> std::optional<std::string> {
   //   // End lifecycle method
 }
 
-// Returns true if the layer is pickable and visible.
-auto Layer::isPickable() const -> bool { return this->props()->pickable && this->props()->visible; }
-
-// auto Layer::getAttributeManager() -> std::shared_ptr<AttributeManager> { return this->attributeManager; }
-
-// Return an array of models used by this layer, can be overriden by layer
-// subclass
-auto Layer::getModels() -> std::list<std::shared_ptr<lumagl::Model>> {
-  return this->models;
-  // return this->state && (this->state.models || (this->state.model ?
-  // [this->state.model] : []));
-}
-
-// Returns the most recent layer that matched to this state
-// (When reacting to an async event, this layer may no longer be the latest)
-// getCurrentLayer() {
-//   return this->internalState && this->internalState->layer;
-// }
-
-// Returns the default parse options for async props
-// getLoadOptions() {
-//   return this->props->loadOptions;
-// }
-
-// PROJECTION METHODS
-
-// Projects a point with current map state (lat, lon, zoom, pitch, bearing)
-// From the current layer"s coordinate system to screen
-/*
-project(xyz) {
-  const {viewport} = this->context;
-  const worldPosition = getWorldPosition(xyz, {
-    viewport,
-    modelMatrix: this->props.modelMatrix,
-    coordinateOrigin: this->props.coordinateOrigin,
-    coordinateSystem: this->props.coordinateSystem
-  });
-  const [x, y, z] = worldToPixels(worldPosition,
-viewport.pixelProjectionMatrix); return xyz.length == 2 ? [x, y] : [x, y,
-z];
-}
-
-// Note: this does not reverse `project`.
-// Always unprojects to the viewport"s coordinate system
-unproject(xy) {
-  const {viewport} = this->context;
-  return viewport.unproject(xy);
-}
-
-projectPosition(xyz) {
-  return projectPosition(xyz, {
-    viewport: this->context->viewport,
-    modelMatrix: this->props.modelMatrix,
-    coordinateOrigin: this->props.coordinateOrigin,
-    coordinateSystem: this->props.coordinateSystem
-  });
-}
-
-use64bitPositions() {
-  const {coordinateSystem} = this->props;
-  return (
-    coordinateSystem == COORDINATE_SYSTEM.DEFAULT ||
-    coordinateSystem == COORDINATE_SYSTEM.LNGLAT ||
-    coordinateSystem == COORDINATE_SYSTEM.CARTESIAN
-  );
-}
-
-// Event handling
-onHover(info, pickingEvent) {
-  if (this->props.onHover) {
-    return this->props.onHover(info, pickingEvent);
-  }
-  return false;
-}
-
-onClick(info, pickingEvent) {
-  if (this->props.onClick) {
-    return this->props.onClick(info, pickingEvent);
-  }
-  return false;
-}
-
-
-// Returns the picking color that doesn"t match any subfeature
-// Use if some graphics do not belong to any pickable subfeature
-// @return {Array} - a black color
-nullPickingColor() {
-  return [0, 0, 0];
-}
-
-// Returns the picking color that doesn"t match any subfeature
-// Use if some graphics do not belong to any pickable subfeature
-encodePickingColor(i, target = []) {
-  target[0] = (i + 1) & 255;
-  target[1] = ((i + 1) >> 8) & 255;
-  target[2] = (((i + 1) >> 8) >> 8) & 255;
-  return target;
-}
-
-// Returns the index corresponding to a picking color that doesn"t match any
-subfeature
-// @param {Uint8Array} color - color array to be decoded
-// @return {Array} - the decoded picking color
-decodePickingColor(color) {
-  assert(color instanceof Uint8Array);
-  const [i1, i2, i3] = color;
-  // 1 was added to seperate from no selection
-  const index = i1 + i2 * 256 + i3 * 65536 - 1;
-  return index;
-}
-*/
-
-// //////////////////////////////////////////////////
-// LIFECYCLE METHODS, overridden by the layer subclasses
-
-// getShaders(shaders) {
-//   for (const extension of this->props.extensions) {
-//     shaders = mergeShaders(shaders, extension.getShaders.call(this,
-//     extension));
-//   }
-//   return shaders;
-// }
 void Layer::initializeState() {}
 
-// Let"s layer control if updateState should be called
 auto Layer::shouldUpdateState(const Layer::ChangeFlags& changeFlags, const std::shared_ptr<Layer::Props>& oldProps)
     -> const std::optional<std::string>& {
   return changeFlags.propsOrDataChanged;
 }
 
-// Default implementation, all attributes will be invalidated and updated
-// when data changes
 void Layer::updateState(const Layer::ChangeFlags& changeFlags, const std::shared_ptr<Layer::Props>& oldProps) {
   /*
   const auto attributeManager = this->getAttributeManager();
@@ -320,61 +122,59 @@ void Layer::updateState(const Layer::ChangeFlags& changeFlags, const std::shared
   */
 }
 
-// Called once when layer is no longer matched and state will be discarded
-// App can destroy WebGL resources here
 void Layer::finalizeState() {}
 
 void Layer::drawState(wgpu::RenderPassEncoder pass) {
-  for (auto model : this->getModels()) {
+  for (auto model : this->models()) {
     model->draw(pass);
   }
 }
 
-// called to populate the info object that is passed to the event handler
-// @return null to cancel event
-// getPickingInfo({info, mode}) {
-//   const {index} = info;
+void Layer::draw(wgpu::RenderPassEncoder pass) {
+  // Call subclass lifecycle method
+  this->drawState(pass);
+  // End lifecycle method
+}
 
-//   if (index >= 0) {
-//     // If props.data is an indexable array, get the object
-//     if (Array.isArray(this->props.data)) {
-//       info.object = this->props.data[index];
-//     }
-//   }
-
-//   return info;
-// }
-
-// END LIFECYCLE METHODS
-// //////////////////////////////////////////////////
-
-// INTERNAL METHODS
-
-// Default implementation of attribute invalidation, can be redefined
-void Layer::invalidateAttribute(const std::string& name, const std::string& diffReason) {
+void Layer::_invalidateAttribute(const std::string& name, const std::string& diffReason) {
   if (name == "all") {
-    this->attributeManager->invalidateAll();
+    this->_attributeManager->invalidateAll();
   } else {
-    this->attributeManager->invalidate(name);
+    this->_attributeManager->invalidate(name);
   }
 }
 
-// void updateAttributes(changedAttributes) {
-//   for (const model of this->getModels()) {
-//     model.setAttributes(shaderAttributes);
-//   }
-// }
+void Layer::_updateAttributes() {
+  /*
+    const auto attributeManager = this->getAttributeManager();
+    if (!attributeManager) {
+      return;
+    }
 
-// LAYER MANAGER API
-// Should only be called by the deck.gl LayerManager class
+    // Figure out data length
+    auto numInstances = this->getNumInstances(props);
+    auto startIndices = 0; this->getStartIndices(props);
 
-// Called by layer manager when a new layer is found
+    attributeManager->update({
+      data: props.data,
+      numInstances,
+      startIndices,
+      transitions: props.transitions,
+      buffers: props.data.attributes,
+      context: this,
+      // Don"t worry about non-attribute props
+      ignoreUnknownAttributes: true
+    });
+
+  // const auto changedAttributes =
+  // attributeManager->getChangedAttributes({clearChangedFlags: true});
+  // this->updateAttributes(changedAttributes);
+  */
+}
+
 void Layer::initialize(const std::shared_ptr<LayerContext>& context) {
-  // debug(TRACE_INITIALIZE, this);
-
   this->context = context;
-  // TODO(ilija@unfolded): Is AttributeManager supposed to be created here?
-  this->attributeManager = std::make_shared<AttributeManager>(this->props()->id, context->device);
+  this->_attributeManager = std::make_shared<AttributeManager>(this->props()->id, context->device);
 
   // Call subclass lifecycle method
   this->initializeState();
@@ -388,14 +188,10 @@ void Layer::initialize(const std::shared_ptr<LayerContext>& context) {
   this->_updateState();
 }
 
-// Called by layer manager
-// if this layer is new (not matched with an existing layer) oldProps will be empty object
 void Layer::update() {
   // Call subclass lifecycle method
   auto stateNeedsUpdate = this->getNeedsUpdate();
   // End lifecycle method
-
-  // debug(TRACE_UPDATE, this, stateNeedsUpdate);
 
   if (stateNeedsUpdate) {
     this->_updateState();
@@ -438,14 +234,6 @@ void Layer::finalize() {
   // End subclass lifecycle method
 }
 
-// Calculates uniforms
-void Layer::draw(wgpu::RenderPassEncoder pass) {
-  // Call subclass lifecycle method
-  this->drawState(pass);
-  // End lifecycle method
-}
-
-// Helper methods
 auto Layer::getChangeFlags() -> Layer::ChangeFlags { return this->_changeFlags; }
 
 void Layer::setDataChangedFlag(const std::string& reason) {
@@ -455,7 +243,6 @@ void Layer::setDataChangedFlag(const std::string& reason) {
   this->_updateChangeFlags();
 }
 
-// Dirty some change flags, will be handled by updateLayer
 void Layer::setPropsChangedFlag(const std::string& reason) {
   if (!this->_changeFlags.propsChanged) {
     this->_changeFlags.propsChanged = reason;
@@ -463,7 +250,6 @@ void Layer::setPropsChangedFlag(const std::string& reason) {
   this->_updateChangeFlags();
 }
 
-// Dirty some change flags, will be handled by updateLayer
 void Layer::setViewportChangedFlag(const std::string& reason) {
   if (!this->_changeFlags.viewportChanged) {
     this->_changeFlags.viewportChanged = reason;
@@ -471,15 +257,11 @@ void Layer::setViewportChangedFlag(const std::string& reason) {
   this->_updateChangeFlags();
 }
 
-// Clear all changeFlags, typically after an update
 void Layer::clearChangeFlags() {
   // Primary changeFlags, can be strings stating reason for change
   this->_changeFlags.dataChanged = std::nullopt;
   this->_changeFlags.propsChanged = std::nullopt;
   this->_changeFlags.viewportChanged = std::nullopt;
-  // this->_changeFlags.updateTriggersChanged = std::nullopt;
-  // this->_changeFlags.stateChanged = std::nullopt;
-  // this->_changeFlags.extensionsChanged = std::nullopt;
 
   this->_changeFlags.propsOrDataChanged = std::nullopt;
   this->_changeFlags.somethingChanged = std::nullopt;
@@ -493,9 +275,6 @@ void Layer::_updateChangeFlags() {
     } else if (this->_changeFlags.propsChanged) {
       this->_changeFlags.propsOrDataChanged = this->_changeFlags.propsChanged;
     }
-
-    // changeFlags.updateTriggersChanged
-    // changeFlags.extensionsChanged;
   }
 
   if (!this->_changeFlags.somethingChanged) {
@@ -504,200 +283,5 @@ void Layer::_updateChangeFlags() {
     } else if (this->_changeFlags.viewportChanged) {
       this->_changeFlags.somethingChanged = this->_changeFlags.viewportChanged;
     }
-    // flags.stateChanged
   }
 }
-
-// Calls attribute manager to update any WebGL attributes
-void Layer::_updateAttributes() {
-  /*
-    const auto attributeManager = this->getAttributeManager();
-    if (!attributeManager) {
-      return;
-    }
-
-    // Figure out data length
-    auto numInstances = this->getNumInstances(props);
-    auto startIndices = 0; this->getStartIndices(props);
-
-    attributeManager->update({
-      data: props.data,
-      numInstances,
-      startIndices,
-      transitions: props.transitions,
-      buffers: props.data.attributes,
-      context: this,
-      // Don"t worry about non-attribute props
-      ignoreUnknownAttributes: true
-    });
-
-  // const auto changedAttributes =
-  // attributeManager->getChangedAttributes({clearChangedFlags: true});
-  // this->updateAttributes(changedAttributes);
-  */
-}
-
-/*
-
-// Compares the layers props with old props from a matched older layer
-// and extracts change flags that describe what has change so that state
-// can be update correctly with minimal effort
-diffProps(newProps, oldProps) {
-  const changeFlags = diffProps(newProps, oldProps);
-
-  // iterate over changedTriggers
-  if (changeFlags.updateTriggersChanged) {
-    for (const key in changeFlags.updateTriggersChanged) {
-      if (changeFlags.updateTriggersChanged[key]) {
-        this->invalidateAttribute(key);
-      }
-    }
-  }
-
-  // trigger uniform transitions
-  if (changeFlags.transitionsChanged) {
-    for (const key in changeFlags.transitionsChanged) {
-      // prop changed and transition is enabled
-      this->internalState->uniformTransitions.add(key, oldProps[key], newProps[key], newProps.transitions[key]);
-    }
-  }
-
-  return this->setChangeFlags(changeFlags);
-}
-
-// Called by layer manager to validate props (in development)
-validateProps() { validateProps(this->props); }
-
-setModuleParameters(moduleParameters) {
-  for (const model of this->getModels()) {
-    model.updateModuleSettings(moduleParameters);
-  }
-}
-
-// PRIVATE METHODS
-_updateModules({props, oldProps}) {
-  // Picking module parameters
-  const {autoHighlight, highlightedObjectIndex, highlightColor} = props;
-  if (oldProps.autoHighlight != = autoHighlight || oldProps.highlightedObjectIndex !=
-      = highlightedObjectIndex || oldProps.highlightColor != = highlightColor) {
-    const parameters = {};
-    if (!autoHighlight) {
-      parameters.pickingSelectedColor = null;
-    }
-    // TODO - fix in luma?
-    highlightColor[3] = highlightColor[3] || 255;
-    parameters.pickingHighlightColor = highlightColor;
-
-    // highlightedObjectIndex will overwrite any settings from auto
-    highlighting.if (Number.isInteger(highlightedObjectIndex)) {
-      parameters.pickingSelectedColor =
-          highlightedObjectIndex >= 0 ? this->encodePickingColor(highlightedObjectIndex) : null;
-    }
-
-    this->setModuleParameters(parameters);
-  }
-}
-
-_getUpdateParams() {
-  return {
-    props : this->props,
-    oldProps : this->internalState->getOldProps(),
-    context : this->context,
-    changeFlags : this->internalState->changeFlags
-  };
-}
-
-// Checks state of attributes and model
-_getNeedsRedraw(opts) {
-  // this method may be called by the render loop as soon a the layer
-  // has been created, so guard against uninitialized state
-  if (!this->internalState) {
-    return false;
-  }
-
-  let redraw = false;
-  redraw = redraw || (this->internalState->needsRedraw && this->id);
-  this->internalState->needsRedraw = this->internalState->needsRedraw && !opts.clearRedrawFlags;
-
-  // TODO - is attribute manager needed? - Model should be enough.
-  const attributeManager = this->getAttributeManager();
-  const attributeManagerNeedsRedraw = attributeManager && attributeManager->getNeedsRedraw(opts);
-  redraw = redraw || attributeManagerNeedsRedraw;
-
-  return redraw;
-}
-
-// Create new attribute manager
-_getAttributeManager() {
-  return new AttributeManager(this->context->gl,
-                              {id : this->props.id, stats : this->context->stats, timeline : this->context->timeline});
-}
-
-_initState() {
-  assert(!this->internalState && !this->state);
-  assert(isFinite(this->props.coordinateSystem), `${this->id} : invalid coordinateSystem`);
-
-  const attributeManager = this->_getAttributeManager();
-
-  if (attributeManager) {
-    // All instanced layers get instancePickingColors attribute by default
-    // Their shaders can use it to render a picking scene
-    // TODO - this slightly slows down non instanced layers
-    attributeManager->addInstanced({
-      instancePickingColors :
-          {type : GL.UNSIGNED_BYTE, size : 3, noAlloc : true, update : this->calculateInstancePickingColors}
-    });
-  }
-
-  this->internalState = new LayerState({attributeManager, layer : this});
-  this->clearChangeFlags();  // populate this->internalState->changeFlags
-
-  this->state = {};
-  // for backwards compatibility with older layers
-  // TODO - remove in next release
-  Object.defineProperty(this->state, "attributeManager", {
-    get: () => {
-      log.deprecated("layer.state.attributeManager",
-"layer.getAttributeManager()"); return attributeManager;
-}
-});
-
-this->internalState->layer = this;
-this->internalState->uniformTransitions = new UniformTransitionManager(this->context->timeline);
-this->internalState->onAsyncPropUpdated = this->_onAsyncPropUpdated.bind(this);
-
-// Ensure any async props are updated
-this->internalState->setAsyncProps(this->props);
-}
-
-// Called by layer manager to transfer state from an old layer
-_transferState(oldLayer) {
-  debug(TRACE_MATCHED, this, this == oldLayer);
-
-  const {state, internalState} = oldLayer;
-  assert(state && internalState);
-
-  if (this == oldLayer) {
-    return;
-  }
-
-  // Move internalState
-  this->internalState = internalState;
-  this->internalState->layer = this;
-
-  // Move state
-  this->state = state;
-  // We keep the state ref on old layers to support async actions
-  // oldLayer.state = null;
-
-  // Ensure any async props are updated
-  this->internalState->setAsyncProps(this->props);
-
-  this->diffProps(this->props, this->internalState->getOldProps());
-}
-
-_onAsyncPropUpdated() {
-  this->diffProps(this->props, this->internalState->getOldProps());
-  this->setNeedsUpdate();
-}
-*/

--- a/cpp/modules/deck.gl/core/src/lib/view-manager.h
+++ b/cpp/modules/deck.gl/core/src/lib/view-manager.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 
 #include "../viewports/viewport.h"
 #include "../views/view-state.h"
@@ -37,19 +38,16 @@ class ViewManager {
   ViewManager();
   virtual ~ViewManager();
 
-  /// \brief Check if a redraw is needed
+  /// \brief Check if a redraw is needed.
   auto getNeedsRedraw(bool clearRedrawFlags = false) -> std::optional<std::string>;
 
-  /// \brief Views will be updated deeply (in next animation frame)
+  /// \brief Views will be updated deeply (in next animation frame).
   void setNeedsUpdate(const std::string &reason);
 
-  /// \brief Checks each viewport for transition updates
-  void updateViewStates();
+  /// \brief Get a set of viewports for a given width and height.
+  auto getViewports() -> std::list<std::shared_ptr<Viewport>>;
 
-  /// \brief Get a set of viewports for a given width and height
-  auto getViewports() -> std::list<std::shared_ptr<Viewport>>;  // (rect)
-
-  auto getViews() -> std::list<std::shared_ptr<View>>;
+  auto getViews() -> std::list<std::shared_ptr<View>> { return this->_views; };
 
   /// \brief Resolves a viewId string to a View, if already a View returns it.
   auto getView(const std::string &viewOrViewId) -> std::shared_ptr<View>;
@@ -77,47 +75,42 @@ class ViewManager {
   // MODIFIERS
   //
 
-  /// \brief Set the size of the window
+  /// \brief Set the size of the window.
   void setSize(int width, int height);
+
+  auto width() -> int { return this->_width; }
   void setWidth(int width);
+
+  auto height() -> int { return this->_height; }
   void setHeight(int height);
 
-  /// \brief Update the view descriptor list (Does not rebuild the `Viewport`s until `getViewports` is called)
+  /// \brief Update the view descriptor list (Does not rebuild the `Viewport`s until `getViewports` is called).
   void setViews(const std::list<std::shared_ptr<View>> &views);
 
-  /// \brief Update the view state
+  /// \brief Update the view state.
   void setViewState(std::shared_ptr<ViewState> viewStates);
-  void setViewStates(const std::list<std::shared_ptr<ViewState>> &viewStates);
-
-  std::list<std::shared_ptr<View>> views;
-  int width{100};
-  int height{100};
-  std::shared_ptr<ViewState> viewState{new ViewState()};
 
  private:
   void _update();
 
-  // Rebuilds viewports from descriptors towards a certain window size
+  /// \brief Rebuilds viewports from descriptors towards a certain window size.
   void _rebuildViewports();
-
-  /*
-  void _onViewStateChange(viewId, event);
-
-  void _createController(props);
-
-  void _updateController(view, viewState, viewport, controller);
-
   void _buildViewportMap();
-  */
 
   // Check if viewport array has changed, returns true if any change
   // Note that descriptors can be the same
   auto _diffViews(const std::list<std::shared_ptr<View>> &newViews,
                   const std::list<std::shared_ptr<View>> &oldViews) const -> bool;
 
+  std::list<std::shared_ptr<View>> _views;
+  int _width{100};
+  int _height{100};
+  std::shared_ptr<ViewState> _viewState{new ViewState()};
+
   std::optional<std::string> _needsRedraw{"Initial render"};
   std::optional<std::string> _needsUpdate{"Initial render"};
-  std::list<std::shared_ptr<Viewport>> _viewports;  // Generated viewports
+  std::list<std::shared_ptr<Viewport>> _viewports;
+  std::unordered_map<std::string, std::shared_ptr<Viewport>> _viewportMap;
   bool _isUpdating{false};
 };
 

--- a/cpp/modules/deck.gl/core/test/lib/view-manager-test.cpp
+++ b/cpp/modules/deck.gl/core/test/lib/view-manager-test.cpp
@@ -29,15 +29,17 @@ using namespace deckgl;
 
 namespace {
 
-TEST(ViewManager, Construct) {
-  auto viewManager = make_shared<ViewManager>();
+/// \brief The fixture for testing ViewManager class.
+class ViewManagerTest : public ::testing::Test {
+ protected:
+  ViewManagerTest() { this->viewManager = std::make_shared<ViewManager>(); }
 
-  EXPECT_TRUE(viewManager != nullptr);
-}
+  std::shared_ptr<ViewManager> viewManager;
+};
 
-TEST(ViewManager, RedrawFlag) {
-  auto viewManager = make_shared<ViewManager>();
+TEST_F(ViewManagerTest, Construct) { EXPECT_TRUE(viewManager != nullptr); }
 
+TEST_F(ViewManagerTest, RedrawFlag) {
   // Initialized needing redraw
   EXPECT_TRUE(viewManager->getNeedsRedraw());
   // Didn't clear redraw
@@ -47,8 +49,8 @@ TEST(ViewManager, RedrawFlag) {
 
   // Changing geometry causes redraw
   viewManager->setSize(10, 20);
-  EXPECT_EQ(viewManager->width, 10);
-  EXPECT_EQ(viewManager->height, 20);
+  EXPECT_EQ(viewManager->width(), 10);
+  EXPECT_EQ(viewManager->height(), 20);
   EXPECT_TRUE(viewManager->getNeedsRedraw(true));
 
   // No-op geometry change does not cause redraw
@@ -60,8 +62,7 @@ TEST(ViewManager, RedrawFlag) {
   EXPECT_TRUE(viewManager->getNeedsRedraw(true));
 }
 
-TEST(ViewManager, SetViews) {
-  auto viewManager = make_shared<ViewManager>();
+TEST_F(ViewManagerTest, SetViews) {
   // Clear redraw flag
   viewManager->getNeedsRedraw(true);
 

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
@@ -68,8 +68,8 @@ class LineLayer::Props : public Layer::Props {
 
   // Property Type Machinery
   auto getProperties() const -> const Properties* override;
-  auto makeComponent(std::shared_ptr<Component::Props> props) const -> LineLayer* override {
-    return new LineLayer{std::dynamic_pointer_cast<LineLayer::Props>(props)};
+  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
+    return std::make_shared<LineLayer>(std::dynamic_pointer_cast<LineLayer::Props>(props));
   }
 
   std::string widthUnits{"pixels"};

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
@@ -97,25 +97,25 @@ void ScatterplotLayer::initializeState() {
   // Using lambdas over std::bind - potential C++ retain cycle issue
   auto position = std::make_shared<arrow::Field>("instancePositions", arrow::fixed_size_list(arrow::float32(), 3));
   auto getPosition = [this](const std::shared_ptr<arrow::Table>& table) { return this->getPositionData(table); };
-  this->attributeManager->add(garrow::ColumnBuilder{position, getPosition});
+  this->_attributeManager->add(garrow::ColumnBuilder{position, getPosition});
 
   auto radius = std::make_shared<arrow::Field>("instanceRadius", arrow::float32());
   auto getRadius = [this](const std::shared_ptr<arrow::Table>& table) { return this->getRadiusData(table); };
-  this->attributeManager->add(garrow::ColumnBuilder{radius, getRadius});
+  this->_attributeManager->add(garrow::ColumnBuilder{radius, getRadius});
 
   auto fillColor = std::make_shared<arrow::Field>("instanceFillColors", arrow::fixed_size_list(arrow::float32(), 4));
   auto getFillColor = [this](const std::shared_ptr<arrow::Table>& table) { return this->getFillColorData(table); };
-  this->attributeManager->add(garrow::ColumnBuilder{fillColor, getFillColor});
+  this->_attributeManager->add(garrow::ColumnBuilder{fillColor, getFillColor});
 
   auto lineColor = std::make_shared<arrow::Field>("instanceLineColors", arrow::fixed_size_list(arrow::float32(), 4));
   auto getLineColor = [this](const std::shared_ptr<arrow::Table>& table) { return this->getLineColorData(table); };
-  this->attributeManager->add(garrow::ColumnBuilder{lineColor, getLineColor});
+  this->_attributeManager->add(garrow::ColumnBuilder{lineColor, getLineColor});
 
   auto lineWidth = std::make_shared<arrow::Field>("instanceLineWidths", arrow::float32());
   auto getLineWidth = [this](const std::shared_ptr<arrow::Table>& table) { return this->getLineWidthData(table); };
-  this->attributeManager->add(garrow::ColumnBuilder{lineWidth, getLineWidth});
+  this->_attributeManager->add(garrow::ColumnBuilder{lineWidth, getLineWidth});
 
-  this->models = {this->_getModel(this->context->device)};
+  this->_models = {this->_getModel(this->context->device)};
   this->_layerUniforms =
       utils::createBuffer(this->context->device, sizeof(ScatterplotLayerUniforms), wgpu::BufferUsage::Uniform);
 }
@@ -152,7 +152,7 @@ void ScatterplotLayer::updateState(const Layer::ChangeFlags& changeFlags,
 void ScatterplotLayer::finalizeState() {}
 
 void ScatterplotLayer::drawState(wgpu::RenderPassEncoder pass) {
-  for (auto const& model : this->getModels()) {
+  for (auto const& model : this->models()) {
     // Layer uniforms are currently bound to index 1
     model->setUniformBuffer(1, this->_layerUniforms);
     model->draw(pass);
@@ -240,7 +240,7 @@ auto ScatterplotLayer::_getModel(wgpu::Device device) -> std::shared_ptr<lumagl:
       std::make_shared<garrow::Array>(this->context->device, positionData, wgpu::BufferUsage::Vertex)};
   model->setAttributes(std::make_shared<garrow::Table>(attributeSchema, attributeArrays));
 
-  auto instancedAttributes = this->attributeManager->update(this->props()->data);
+  auto instancedAttributes = this->_attributeManager->update(this->props()->data);
   model->setInstancedAttributes(instancedAttributes);
 
   return model;

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
@@ -67,8 +67,8 @@ class ScatterplotLayer::Props : public Layer::Props {
 
   // Property Type Machinery
   auto getProperties() const -> const Properties* override;
-  auto makeComponent(std::shared_ptr<Component::Props> props) const -> ScatterplotLayer* override {
-    return new ScatterplotLayer{std::dynamic_pointer_cast<ScatterplotLayer::Props>(props)};
+  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
+    return std::make_shared<ScatterplotLayer>(std::dynamic_pointer_cast<ScatterplotLayer::Props>(props));
   }
 
   bool filled{true};

--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.h
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.h
@@ -72,8 +72,8 @@ class SolidPolygonLayer::Props : public Layer::Props {
 
   // Property Type Machinery
   auto getProperties() const -> const Properties* override;
-  auto makeComponent(std::shared_ptr<Component::Props> props) const -> SolidPolygonLayer* override {
-    return new SolidPolygonLayer{std::dynamic_pointer_cast<SolidPolygonLayer::Props>(props)};
+  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
+    return std::make_shared<SolidPolygonLayer>(std::dynamic_pointer_cast<SolidPolygonLayer::Props>(props));
   }
 
   bool filled{true};

--- a/cpp/modules/luma.gl/CMakeLists.txt
+++ b/cpp/modules/luma.gl/CMakeLists.txt
@@ -54,6 +54,7 @@ set(GARROW_HEADER_FILE_LIST
     )
 set(GARROW_SOURCE_FILE_LIST
     garrow/src/key-value-metadata.cc
+    garrow/src/field.cc
     garrow/src/schema.cc
     garrow/src/array.cc
     garrow/src/table.cc
@@ -133,7 +134,7 @@ if (DECK_ENABLE_D3D12)
         list(APPEND WEBGPU_SOURCE_FILE_LIST webgpu/src/backends/glfw/d3d12-binding.cpp)
     endif()
 
-    # TODO: Currently not supported. Should link against D3D12 libs
+    # TODO(ilija@unfolded.ai): Currently not supported. Should link against D3D12 libs
 endif()
 if (DECK_ENABLE_METAL)
     if (LUMAGL_USES_GLFW)

--- a/cpp/modules/luma.gl/core/src/animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/animation-loop.cpp
@@ -41,12 +41,7 @@ AnimationLoop::AnimationLoop(const Options& options) : _size{options.size} {
   }
 }
 
-AnimationLoop::~AnimationLoop() {
-  // TODO(ilija@unfolded.ai): Cleanup?
-}
-
 void AnimationLoop::draw(wgpu::TextureView textureView, std::function<void(wgpu::RenderPassEncoder)> onRender) {
-  // TODO(ilija@unfolded.ai): There seems to be a memory leak, what do we need to free?
   utils::ComboRenderPassDescriptor passDescriptor({textureView});
   wgpu::CommandEncoder encoder = this->_device.CreateCommandEncoder();
   wgpu::RenderPassEncoder pass = encoder.BeginRenderPass(&passDescriptor);
@@ -70,7 +65,6 @@ void AnimationLoop::draw(wgpu::TextureView textureView, std::function<void(wgpu:
 
 void AnimationLoop::run(std::function<void(wgpu::RenderPassEncoder)> onRender) {
   this->running = true;
-  // TODO(ilija@unfolded.ai): Add needsRedraw and check it
   while (this->running && !this->shouldQuit()) {
     this->draw(onRender);
     // TODO(ib@unfolded.ai): We should not wait 16ms, we should wait **max** 16ms.

--- a/cpp/modules/luma.gl/core/src/animation-loop.h
+++ b/cpp/modules/luma.gl/core/src/animation-loop.h
@@ -35,7 +35,7 @@ class AnimationLoop {
   struct Options;
 
   explicit AnimationLoop(const Options& options);
-  virtual ~AnimationLoop();
+  virtual ~AnimationLoop(){};
 
   virtual void draw(std::function<void(wgpu::RenderPassEncoder)> onRender) {}
   virtual void draw(wgpu::TextureView textureView, std::function<void(wgpu::RenderPassEncoder)> onRender);

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.cpp
@@ -56,8 +56,6 @@ GLFWAnimationLoop::GLFWAnimationLoop(const Options& options) : AnimationLoop{opt
 GLFWAnimationLoop::~GLFWAnimationLoop() {
   glfwDestroyWindow(this->_window);
   glfwTerminate();
-
-  // TODO(ilija@unfolded.ai): Additional cleanup?
 }
 
 void GLFWAnimationLoop::draw(std::function<void(wgpu::RenderPassEncoder)> onRender) {
@@ -76,8 +74,6 @@ bool GLFWAnimationLoop::shouldQuit() { return glfwWindowShouldClose(this->_windo
 void GLFWAnimationLoop::flush() { glfwPollEvents(); }
 
 auto GLFWAnimationLoop::getPreferredSwapChainTextureFormat() -> wgpu::TextureFormat {
-  // TODO(ilija@unfolded.ai): Why do we flush here?
-  this->flush();
   return static_cast<wgpu::TextureFormat>(this->_binding->GetPreferredSwapChainTextureFormat());
 }
 

--- a/cpp/modules/luma.gl/core/src/model.cpp
+++ b/cpp/modules/luma.gl/core/src/model.cpp
@@ -33,6 +33,8 @@ using namespace lumagl::utils;
 Model::Model(wgpu::Device device, const Model::Options& options) {
   this->_device = device;
   this->_uniformDescriptors = options.uniforms;
+  this->_attributeSchema = options.attributeSchema;
+  this->_instancedAttributeSchema = options.instancedAttributeSchema;
 
   this->vsModule = createShaderModule(device, SingleShaderStage::Vertex, options.vs.c_str());
   this->fsModule = createShaderModule(device, SingleShaderStage::Fragment, options.fs.c_str());
@@ -66,13 +68,9 @@ Model::Model(wgpu::Device device, const Model::Options& options) {
       std::make_shared<garrow::Table>(schema, std::vector<std::shared_ptr<garrow::Array>>{});
 }
 
-void Model::setAttributes(const std::shared_ptr<garrow::Table>& attributes) {
-  // TODO(ilija@unfolded.ai): Compare to schema provided in the constructor?
-  this->_attributeTable = attributes;
-}
+void Model::setAttributes(const std::shared_ptr<garrow::Table>& attributes) { this->_attributeTable = attributes; }
 
 void Model::setInstancedAttributes(const std::shared_ptr<garrow::Table>& attributes) {
-  // TODO(ilija@unfolded.ai): Compare to schema provided in the constructor?
   this->_instancedAttributeTable = attributes;
 }
 

--- a/cpp/modules/luma.gl/core/src/model.h
+++ b/cpp/modules/luma.gl/core/src/model.h
@@ -34,7 +34,6 @@
 namespace lumagl {
 
 /// \brief Collection of keys that provide additional attribute context when present in input scheme metadata.
-// TODO(ilija@unfolded.ai): Document metadata properties and the behavior they trigger once we finalize the list
 struct AttributePropertyKeys {};
 
 struct UniformDescriptor {
@@ -92,11 +91,12 @@ class Model {
   void _setVertexBuffers(wgpu::RenderPassEncoder pass);
 
   wgpu::Device _device;
+  std::shared_ptr<garrow::Schema> _attributeSchema;
+  std::shared_ptr<garrow::Schema> _instancedAttributeSchema;
   std::shared_ptr<garrow::Table> _attributeTable;
   std::shared_ptr<garrow::Table> _instancedAttributeTable;
   std::shared_ptr<garrow::Array> _indices;
   std::vector<UniformDescriptor> _uniformDescriptors;
-  // TODO(ilija@unfolded.ai) Should probably be a map
   std::vector<std::optional<utils::BindingInitializationHelper>> _bindings;
 };
 

--- a/cpp/modules/luma.gl/garrow/src/array.h
+++ b/cpp/modules/luma.gl/garrow/src/array.h
@@ -53,7 +53,6 @@ class Array {
 
   /* Arrow non-compliant API */
 
-  // TODO(ilija@unfolded.ai): Arrays are not mutable in Arrow. Revisit once ArrayData is in place
   void setData(const std::shared_ptr<arrow::Array>& data, wgpu::BufferUsage usage);
   template <typename T>
   void setData(const T* data, size_t length, wgpu::BufferUsage usage) {

--- a/cpp/modules/luma.gl/garrow/src/field.cc
+++ b/cpp/modules/luma.gl/garrow/src/field.cc
@@ -22,45 +22,26 @@
 
 using namespace lumagl::garrow;
 
-// TODO(ilija@unfolded.ai): Metadata and fingerprinting not implemented
-auto Schema::Equals(const Schema& other, bool check_metadata) const -> bool {
+auto Field::Equals(const Field& other, bool check_metadata) const -> bool {
   if (this == &other) {
     return true;
   }
 
-  if (num_fields() != other.num_fields()) {
-    return false;
-  }
-
-  for (int i = 0; i < num_fields(); ++i) {
-    if (!field(i)->Equals(*other.field(i).get(), check_metadata)) {
+  if (this->_name == other._name && this->_nullable == other._nullable && this->_type == other._type) {
+    if (!check_metadata) {
+      return true;
+    } else if (this->HasMetadata() && other.HasMetadata()) {
+      return this->_metadata->Equals(*other._metadata);
+    } else if (!this->HasMetadata() && !other.HasMetadata()) {
+      return true;
+    } else {
       return false;
     }
   }
 
-  return true;
+  return false;
 }
 
-auto Schema::Equals(const std::shared_ptr<Schema>& other, bool check_metadata) const -> bool {
-  if (other == nullptr) {
-    return false;
-  }
-
-  return this->Equals(*other, check_metadata);
-}
-
-auto Schema::field_names() const -> std::vector<std::string> {
-  std::vector<std::string> names;
-  std::transform(this->_fields.begin(), this->_fields.end(), std::back_inserter(names),
-                 [](std::shared_ptr<Field> field) { return field->name(); });
-  return names;
-};
-
-auto Schema::GetFieldByName(const std::string& name) const -> std::shared_ptr<Field> {
-  for (auto const& field : this->_fields) {
-    if (field->name() == name) {
-      return field;
-    }
-  }
-  return nullptr;
+auto Field::Equals(const std::shared_ptr<Field>& other, bool check_metadata) const -> bool {
+  return Equals(*other.get(), check_metadata);
 }

--- a/cpp/modules/luma.gl/garrow/src/field.h
+++ b/cpp/modules/luma.gl/garrow/src/field.h
@@ -60,6 +60,15 @@ class Field {
   /// \brief Return whether the field has non-empty metadata.
   auto HasMetadata() const -> bool { return this->_metadata != nullptr && this->_metadata->size() > 0; };
 
+  /// \brief Indicate if fields are equals.
+  ///
+  /// \param[in] other field to check equality with.
+  /// \param[in] check_metadata controls if it should check for metadata equality.
+  ///
+  /// \return true if fields are equal, false otherwise.
+  auto Equals(const Field& other, bool check_metadata = true) const -> bool;
+  auto Equals(const std::shared_ptr<Field>& other, bool check_metadata = true) const -> bool;
+
  private:
   std::string _name;
   wgpu::VertexFormat _type;

--- a/cpp/modules/luma.gl/garrow/src/key-value-metadata.cc
+++ b/cpp/modules/luma.gl/garrow/src/key-value-metadata.cc
@@ -20,6 +20,8 @@
 
 #include "./key-value-metadata.h"  // NOLINT(build/include)
 
+#include <algorithm>
+
 using namespace lumagl::garrow;
 
 KeyValueMetadata::KeyValueMetadata() {}
@@ -62,4 +64,13 @@ auto KeyValueMetadata::FindKey(const std::string& key) const -> int {
   }
 
   return -1;
+}
+
+auto KeyValueMetadata::Equals(const KeyValueMetadata& other) const -> bool {
+  if (size() != other.size()) {
+    return false;
+  }
+
+  // TODO(ilija@unfolded.ai): Sort these before comparing
+  return this->_keys == other._keys && this->_values == other._values;
 }

--- a/cpp/modules/luma.gl/garrow/src/key-value-metadata.h
+++ b/cpp/modules/luma.gl/garrow/src/key-value-metadata.h
@@ -58,6 +58,10 @@ class KeyValueMetadata {
   /// \param key Key to search for.
   int FindKey(const std::string& key) const;
 
+  /// \brief Compares this metadata container with *other* argument.
+  /// \param other Metadata object to compare against.
+  auto Equals(const KeyValueMetadata& other) const -> bool;
+
  private:
   std::vector<std::string> _keys;
   std::vector<std::string> _values;

--- a/cpp/modules/luma.gl/garrow/src/schema.h
+++ b/cpp/modules/luma.gl/garrow/src/schema.h
@@ -31,10 +31,14 @@
 namespace lumagl {
 namespace garrow {
 
-/// \brief Sequence of WebGPUField objects describing the columns of a table data structure.
+/// \brief Sequence of Field objects describing the columns of a table data structure.
 class Schema {
  public:
   explicit Schema(const std::vector<std::shared_ptr<Field>>& fields) : _fields{fields} {}
+
+  /// \brief Returns true if all of the schema fields are equal.
+  auto Equals(const Schema& other, bool check_metadata = true) const -> bool;
+  auto Equals(const std::shared_ptr<Schema>& other, bool check_metadata = true) const -> bool;
 
   /// \brief Returns number of fields that this schema contains.
   auto num_fields() const -> int { return static_cast<int>(this->_fields.size()); }
@@ -52,6 +56,7 @@ class Schema {
   auto GetFieldByName(const std::string& name) const -> std::shared_ptr<Field>;
 
  private:
+  // TODO(ilija@unfolded.ai): Use a map if field_names/GetFieldByName are used commonly
   std::vector<std::shared_ptr<Field>> _fields;
 };
 

--- a/cpp/modules/luma.gl/garrow/src/util/arrow-utils.cc
+++ b/cpp/modules/luma.gl/garrow/src/util/arrow-utils.cc
@@ -28,8 +28,6 @@ namespace garrow {
 auto vertexFormatFromArrowListType(const std::shared_ptr<arrow::FixedSizeListType>& type)
     -> std::optional<wgpu::VertexFormat>;
 
-// TODO(ilija@unfolded.ai): Revisit and use maps instead
-
 auto arrowTypeFromVertexFormat(wgpu::VertexFormat format) -> std::shared_ptr<arrow::DataType> {
   // Based on https://gpuweb.github.io/gpuweb/#vertex-formats
   // uchar = unsigned 8-bit value

--- a/cpp/modules/math.gl/core/src/core.h
+++ b/cpp/modules/math.gl/core/src/core.h
@@ -232,7 +232,6 @@ class Vector4 {
 
   auto transform(const Matrix4<coord> &m) const -> Vector4<coord>;
 
-  // TODO(ilija@unfolded.ai): These are not implemented?
   coord length() const;
   coord length2() const;
   auto toVector3() const -> Vector3<coord>;

--- a/deck.gl-native.xcodeproj/project.pbxproj
+++ b/deck.gl-native.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		CD452A51244852DE00DD44A5 /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = CD452A4E244852DE00DD44A5 /* field.h */; };
 		CD452A552448565000DD44A5 /* schema.cc in Sources */ = {isa = PBXBuildFile; fileRef = CD452A522448565000DD44A5 /* schema.cc */; };
 		CD452A562448565000DD44A5 /* schema.h in Headers */ = {isa = PBXBuildFile; fileRef = CD452A532448565000DD44A5 /* schema.h */; };
+		CD4B3B16248508B8007756A6 /* field.cc in Sources */ = {isa = PBXBuildFile; fileRef = CD4B3B15248508B8007756A6 /* field.cc */; };
 		CD57340F24640A3300D22A70 /* blit-model.cc in Sources */ = {isa = PBXBuildFile; fileRef = CD57340D24640A3300D22A70 /* blit-model.cc */; };
 		CD57341024640A3300D22A70 /* blit-model.h in Headers */ = {isa = PBXBuildFile; fileRef = CD57340E24640A3300D22A70 /* blit-model.h */; };
 		CD57341224640E6200D22A70 /* size.h in Headers */ = {isa = PBXBuildFile; fileRef = CD57341124640E6200D22A70 /* size.h */; };
@@ -476,6 +477,7 @@
 		CD452A522448565000DD44A5 /* schema.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = schema.cc; sourceTree = "<group>"; };
 		CD452A532448565000DD44A5 /* schema.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = schema.h; sourceTree = "<group>"; };
 		CD48E81024178A1E00D3C13C /* deck.gl-native-tests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "deck.gl-native-tests"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD4B3B15248508B8007756A6 /* field.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = field.cc; sourceTree = "<group>"; };
 		CD517429243DC4A50051AB3F /* libshaderc_spvc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libshaderc_spvc.dylib; path = "cpp/deps/x64-osx/lib/libshaderc_spvc.dylib"; sourceTree = "<group>"; };
 		CD57340D24640A3300D22A70 /* blit-model.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "blit-model.cc"; sourceTree = "<group>"; };
 		CD57340E24640A3300D22A70 /* blit-model.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "blit-model.h"; sourceTree = "<group>"; };
@@ -1003,6 +1005,7 @@
 				CDC8E170244D6420002A7E60 /* key-value-metadata.cc */,
 				CDC8E171244D6420002A7E60 /* key-value-metadata.h */,
 				CD452A4E244852DE00DD44A5 /* field.h */,
+				CD4B3B15248508B8007756A6 /* field.cc */,
 				CD452A532448565000DD44A5 /* schema.h */,
 				CD452A522448565000DD44A5 /* schema.cc */,
 				CDE55B48243C6A10000D8EC6 /* array.h */,
@@ -2454,6 +2457,7 @@
 				CDE577A3243C6A1F000D8EC6 /* webgpu-utils.cpp in Sources */,
 				CDE5776B243C6A1F000D8EC6 /* animation-loop.cpp in Sources */,
 				CDE57848243C6A1F000D8EC6 /* json-object.cpp in Sources */,
+				CD4B3B16248508B8007756A6 /* field.cc in Sources */,
 				CDE57773243C6A1F000D8EC6 /* model.cpp in Sources */,
 				CDE577E1243C6A1F000D8EC6 /* row.cc in Sources */,
 				CD1CCD8E24446CEB00C96D72 /* array.cc in Sources */,


### PR DESCRIPTION
There was a lot of dead code that were leftovers from the initial port, cleaned it up and consolidated some of the APIs. I know these kind of changes are hard to review, but it piled up over time and had to be cleaned up.

Also tried putting dirty flag API in place that would avoid full redraw on each frame, the pieces in `Deck`/`ViewManager`/`LayerManager` should be in place, but we're still missing the actual state tracking in `Layer`, so this isn't complete