### PR TITLE
JSON properties consolidated, additional JSONConverter tests

### DIFF
--- a/cpp/modules/deck.gl/CMakeLists.txt
+++ b/cpp/modules/deck.gl/CMakeLists.txt
@@ -70,6 +70,7 @@ set(CORE_HEADER_FILES
 set(CORE_SOURCE_FILES
     core/src/core.cpp
     core/src/lib/attribute/attribute-manager.cc
+    core/src/lib/component.cc
     core/src/lib/constants.cpp
     core/src/lib/deck.cpp
     core/src/lib/layer.cpp

--- a/cpp/modules/deck.gl/core/src/lib/component.cc
+++ b/cpp/modules/deck.gl/core/src/lib/component.cc
@@ -25,7 +25,7 @@ using namespace deckgl;
 // Setters and getters for properties
 // TODO(ib@unfolded.ai): auto generate from language-independent prop definition schema
 // TODO(ilija@unfolded.ai): Generate a unique id instead of an empty string for default value?
-static const std::vector<const std::shared_ptr<Property>> propTypeDefs = {std::make_shared<PropertyT<std::string>>(
+static const std::vector<std::shared_ptr<Property>> propTypeDefs = {std::make_shared<PropertyT<std::string>>(
     "id", [](const JSONObject* props) { return dynamic_cast<const Component::Props*>(props)->id; },
     [](JSONObject* props, std::string value) { return dynamic_cast<Component::Props*>(props)->id = value; }, "")};
 

--- a/cpp/modules/deck.gl/core/src/lib/component.cc
+++ b/cpp/modules/deck.gl/core/src/lib/component.cc
@@ -18,26 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef DECKGL_CORE_CORE_H
-#define DECKGL_CORE_CORE_H
+#include "./component.h"  // NOLINT(build/include)
 
-#include "./arrow/arrow-mapper.h"
-#include "./arrow/row.h"
-#include "./lib/attribute/attribute-manager.h"
-#include "./lib/constants.h"
-#include "./lib/deck.h"
-#include "./lib/layer.h"
-#include "./shaderlib/project/viewport-uniforms.h"
-#include "./viewports/viewport.h"
-#include "./viewports/web-mercator-viewport.h"
-#include "./views/map-view.h"
-#include "./views/view-state.h"
-#include "./views/view.h"
+using namespace deckgl;
 
-namespace deckgl {
+// Setters and getters for properties
+// TODO(ib@unfolded.ai): auto generate from language-independent prop definition schema
+// TODO(ilija@unfolded.ai): Generate a unique id instead of an empty string for default value?
+static const std::vector<const std::shared_ptr<Property>> propTypeDefs = {std::make_shared<PropertyT<std::string>>(
+    "id", [](const JSONObject* props) { return dynamic_cast<const Component::Props*>(props)->id; },
+    [](JSONObject* props, std::string value) { return dynamic_cast<Component::Props*>(props)->id = value; }, "")};
 
-void registerJSONConvertersForDeckCore(JSONConverter *);
-
-}  // namespace deckgl
-
-#endif  // DECKGL_CORE_CORE_H
+auto Component::Props::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<Component::Props>("Component", propTypeDefs);
+  return properties;
+}

--- a/cpp/modules/deck.gl/core/src/lib/component.cc
+++ b/cpp/modules/deck.gl/core/src/lib/component.cc
@@ -30,6 +30,6 @@ static const std::vector<std::shared_ptr<Property>> propTypeDefs = {std::make_sh
     [](JSONObject* props, std::string value) { return dynamic_cast<Component::Props*>(props)->id = value; }, "")};
 
 auto Component::Props::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<Component::Props>("Component", propTypeDefs);
+  static auto properties = Properties::from<Component::Props>(propTypeDefs);
   return properties;
 }

--- a/cpp/modules/deck.gl/core/src/lib/component.h
+++ b/cpp/modules/deck.gl/core/src/lib/component.h
@@ -22,8 +22,9 @@
 #define DECKGL_CORE_LIB_COMPONENT_H
 
 #include <memory>
+#include <string>
 
-#include "deck.gl/json.h"  // {JSONObject}
+#include "deck.gl/json.h"
 
 namespace deckgl {
 
@@ -40,9 +41,13 @@ class Component {
 class Component::Props : public JSONObject {
  public:
   using super = JSONObject;
+
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
   virtual auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> {
     return std::make_shared<Component>(std::dynamic_pointer_cast<Component::Props>(props));
   }
+
+  std::string id;
 };
 
 }  // namespace deckgl

--- a/cpp/modules/deck.gl/core/src/lib/component.h
+++ b/cpp/modules/deck.gl/core/src/lib/component.h
@@ -42,6 +42,7 @@ class Component::Props : public JSONObject {
  public:
   using super = JSONObject;
 
+  static constexpr const char* getTypeName() { return "Component"; }
   auto getProperties() const -> const std::shared_ptr<Properties> override;
   virtual auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> {
     return std::make_shared<Component>(std::dynamic_pointer_cast<Component::Props>(props));

--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -53,7 +53,7 @@ static const std::vector<std::shared_ptr<Property>> propTypeDefs = {
         })};
 
 auto Deck::Props::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<Deck::Props>("Deck", propTypeDefs);
+  static auto properties = Properties::from<Deck::Props>(propTypeDefs);
   return properties;
 }
 

--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -29,7 +29,7 @@ using namespace deckgl;
 
 // Setters and getters for properties
 // TODO(ib@unfolded.ai): auto generate from language-independent prop definition schema
-static const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+static const std::vector<std::shared_ptr<Property>> propTypeDefs = {
     std::make_shared<PropertyT<std::list<std::shared_ptr<Layer::Props>>>>(
         "layers", [](const JSONObject* props) { return dynamic_cast<const Deck::Props*>(props)->layers; },
         [](JSONObject* props, std::list<std::shared_ptr<Layer::Props>> value) {

--- a/cpp/modules/deck.gl/core/src/lib/deck.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cpp
@@ -29,32 +29,32 @@ using namespace deckgl;
 
 // Setters and getters for properties
 // TODO(ib@unfolded.ai): auto generate from language-independent prop definition schema
-static const std::vector<const Property*> propTypeDefs = {
-    new PropertyT<std::list<std::shared_ptr<Layer::Props>>>{
+static const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+    std::make_shared<PropertyT<std::list<std::shared_ptr<Layer::Props>>>>(
         "layers", [](const JSONObject* props) { return dynamic_cast<const Deck::Props*>(props)->layers; },
         [](JSONObject* props, std::list<std::shared_ptr<Layer::Props>> value) {
           return dynamic_cast<Deck::Props*>(props)->layers = value;
-        }},
-    new PropertyT<std::list<std::shared_ptr<View>>>{
+        }),
+    std::make_shared<PropertyT<std::list<std::shared_ptr<View>>>>(
         "views", [](const JSONObject* props) { return dynamic_cast<const Deck::Props*>(props)->views; },
         [](JSONObject* props, std::list<std::shared_ptr<View>> value) {
           return dynamic_cast<Deck::Props*>(props)->views = value;
-        }},
-    new PropertyT<std::shared_ptr<ViewState>>{
+        }),
+    std::make_shared<PropertyT<std::shared_ptr<ViewState>>>(
         "viewState", [](const JSONObject* props) { return dynamic_cast<const Deck::Props*>(props)->viewState; },
         [](JSONObject* props, std::shared_ptr<ViewState> value) {
           return dynamic_cast<Deck::Props*>(props)->viewState = value;
-        }},
-    new PropertyT<std::shared_ptr<ViewState>>{
+        }),
+    std::make_shared<PropertyT<std::shared_ptr<ViewState>>>(
         "initialViewState",
         [](const JSONObject* props) { return dynamic_cast<const Deck::Props*>(props)->initialViewState; },
         [](JSONObject* props, std::shared_ptr<ViewState> value) {
           return dynamic_cast<Deck::Props*>(props)->initialViewState = value;
-        }}};
+        })};
 
-auto Deck::Props::getProperties() const -> const Properties* {
-  static Properties properties{Properties::from<Deck::Props>("Deck", propTypeDefs)};
-  return &properties;
+auto Deck::Props::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<Deck::Props>("Deck", propTypeDefs);
+  return properties;
 }
 
 Deck::Deck(std::shared_ptr<Deck::Props> props)

--- a/cpp/modules/deck.gl/core/src/lib/deck.h
+++ b/cpp/modules/deck.gl/core/src/lib/deck.h
@@ -82,7 +82,6 @@ class Deck::Props : public Component::Props {
  public:
   using super = Component::Props;
 
-  std::string id{"deckgl"};
   int width{100};   // Dummy value, ensure something is visible if user forgets to set window size
   int height{100};  // Dummy value, ensure something is visible if user forgets to set window size
 
@@ -103,7 +102,7 @@ class Deck::Props : public Component::Props {
 
   // Prop Type Machinery
   static constexpr const char* getTypeName() { return "Deck"; }
-  auto getProperties() const -> const Properties* override;
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
   auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
     return std::make_shared<Deck>(std::dynamic_pointer_cast<Deck::Props>(props));
   }

--- a/cpp/modules/deck.gl/core/src/lib/layer.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/layer.cpp
@@ -27,42 +27,50 @@ using namespace deckgl;
 
 // Setters and getters for properties
 // TODO(ib@unfolded.ai): auto generate from language-independent prop definition schema
-static const std::vector<const Property*> propTypeDefs = {
-    new PropertyT<bool>{
+static const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+    std::make_shared<PropertyT<bool>>(
         "visible", [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->visible; },
-        [](JSONObject* props, bool value) { return dynamic_cast<Layer::Props*>(props)->visible = value; }, true},
-    new PropertyT<float>{
+        [](JSONObject* props, bool value) { return dynamic_cast<Layer::Props*>(props)->visible = value; }, true),
+    std::make_shared<PropertyT<float>>(
         "opacity", [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->opacity; },
-        [](JSONObject* props, float value) { return dynamic_cast<Layer::Props*>(props)->opacity = value; }, 1.0},
-    new PropertyT<COORDINATE_SYSTEM>{
+        [](JSONObject* props, float value) { return dynamic_cast<Layer::Props*>(props)->opacity = value; }, 1.0),
+    std::make_shared<PropertyT<COORDINATE_SYSTEM>>(
         "coordinateSystem",
         [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->coordinateSystem; },
         [](JSONObject* props, COORDINATE_SYSTEM value) {
           return dynamic_cast<Layer::Props*>(props)->coordinateSystem = value;
         },
-        COORDINATE_SYSTEM::DEFAULT},
-    new PropertyT<Vector3<double>>{
+        COORDINATE_SYSTEM::DEFAULT),
+    std::make_shared<PropertyT<Vector3<double>>>(
         "coordinateOrigin",
         [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->coordinateOrigin; },
         [](JSONObject* props, Vector3<double> value) {
           return dynamic_cast<Layer::Props*>(props)->coordinateOrigin = value;
         },
-        Vector3<double>()},
-    new PropertyT<Matrix4<double>>{
+        Vector3<double>()),
+    std::make_shared<PropertyT<Matrix4<double>>>(
         "modelMatrix", [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->modelMatrix; },
         [](JSONObject* props, Matrix4<double> value) {
           return dynamic_cast<Layer::Props*>(props)->modelMatrix = value;
         },
-        Matrix4<double>()},
-    new PropertyT<bool>{
+        Matrix4<double>()),
+    std::make_shared<PropertyT<bool>>(
         "wrapLongitude",
         [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->wrapLongitude; },
-        [](JSONObject* props, bool value) { return dynamic_cast<Layer::Props*>(props)->wrapLongitude = value; },
-        false}};
+        [](JSONObject* props, bool value) { return dynamic_cast<Layer::Props*>(props)->wrapLongitude = value; }, false),
+    std::make_shared<PropertyT<std::string>>(
+        "positionFormat",
+        [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->positionFormat; },
+        [](JSONObject* props, std::string value) { return dynamic_cast<Layer::Props*>(props)->positionFormat = value; },
+        "XYZ"),
+    std::make_shared<PropertyT<std::string>>(
+        "colorFormat", [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->colorFormat; },
+        [](JSONObject* props, std::string value) { return dynamic_cast<Layer::Props*>(props)->colorFormat = value; },
+        "RGBA")};
 
-auto Layer::Props::getProperties() const -> const Properties* {
-  static Properties properties{Properties::from<Layer::Props>("Layer", propTypeDefs)};
-  return &properties;
+auto Layer::Props::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<Layer::Props>("Layer", propTypeDefs);
+  return properties;
 }
 
 void Layer::setProps(std::shared_ptr<Layer::Props> newProps) {

--- a/cpp/modules/deck.gl/core/src/lib/layer.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/layer.cpp
@@ -27,7 +27,7 @@ using namespace deckgl;
 
 // Setters and getters for properties
 // TODO(ib@unfolded.ai): auto generate from language-independent prop definition schema
-static const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+static const std::vector<std::shared_ptr<Property>> propTypeDefs = {
     std::make_shared<PropertyT<bool>>(
         "visible", [](const JSONObject* props) { return dynamic_cast<const Layer::Props*>(props)->visible; },
         [](JSONObject* props, bool value) { return dynamic_cast<Layer::Props*>(props)->visible = value; }, true),

--- a/cpp/modules/deck.gl/core/src/lib/layer.cpp
+++ b/cpp/modules/deck.gl/core/src/lib/layer.cpp
@@ -69,7 +69,7 @@ static const std::vector<std::shared_ptr<Property>> propTypeDefs = {
         "RGBA")};
 
 auto Layer::Props::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<Layer::Props>("Layer", propTypeDefs);
+  static auto properties = Properties::from<Layer::Props>(propTypeDefs);
   return properties;
 }
 

--- a/cpp/modules/deck.gl/core/src/lib/layer.h
+++ b/cpp/modules/deck.gl/core/src/lib/layer.h
@@ -171,9 +171,6 @@ class Layer : public Component {
 class Layer::Props : public Component::Props {
  public:
   using super = Component::Props;
-  static constexpr const char* getTypeName() { return "Layer"; }
-
-  std::string id;
 
   std::shared_ptr<arrow::Table> data;
 
@@ -189,7 +186,8 @@ class Layer::Props : public Component::Props {
   std::string colorFormat{"RGBA"};
 
   // Property Type Machinery
-  auto getProperties() const -> const Properties* override;
+  static constexpr const char* getTypeName() { return "Layer"; }
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
   auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
     return std::make_shared<Layer>(std::dynamic_pointer_cast<Layer::Props>(props));
   }

--- a/cpp/modules/deck.gl/core/src/views/map-view.cpp
+++ b/cpp/modules/deck.gl/core/src/views/map-view.cpp
@@ -29,7 +29,7 @@ using namespace deckgl;
 using namespace mathgl;
 
 auto MapView::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<MapView>("MapView");
+  static auto properties = Properties::from<MapView>();
   return properties;
 }
 

--- a/cpp/modules/deck.gl/core/src/views/map-view.cpp
+++ b/cpp/modules/deck.gl/core/src/views/map-view.cpp
@@ -28,9 +28,9 @@ using namespace std;
 using namespace deckgl;
 using namespace mathgl;
 
-auto MapView::getProperties() const -> const Properties* {
-  static Properties properties{Properties::from<MapView>("MapView")};
-  return &properties;
+auto MapView::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<MapView>("MapView");
+  return properties;
 }
 
 auto MapView::_getViewport(const Rectangle<int>& rect, shared_ptr<ViewState> viewState) const -> shared_ptr<Viewport> {

--- a/cpp/modules/deck.gl/core/src/views/map-view.h
+++ b/cpp/modules/deck.gl/core/src/views/map-view.h
@@ -33,8 +33,9 @@ class MapView : public View {
  public:
   using super = View;
 
+  // Property Type Machinery
   static constexpr const char* getTypeName() { return "MapView"; }
-  auto getProperties() const -> const Properties* override;
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
 
  protected:
   auto _getViewport(const mathgl::Rectangle<int>& rect, std::shared_ptr<ViewState> viewState) const

--- a/cpp/modules/deck.gl/core/src/views/view-state.cpp
+++ b/cpp/modules/deck.gl/core/src/views/view-state.cpp
@@ -22,7 +22,7 @@
 
 using namespace deckgl;
 
-const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+const std::vector<std::shared_ptr<Property>> propTypeDefs = {
     std::make_shared<PropertyT<std::optional<double>>>(
         "longitude", [](const JSONObject* props) { return dynamic_cast<const ViewState*>(props)->longitude; },
         [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->longitude = value; }, 0.0),

--- a/cpp/modules/deck.gl/core/src/views/view-state.cpp
+++ b/cpp/modules/deck.gl/core/src/views/view-state.cpp
@@ -22,24 +22,24 @@
 
 using namespace deckgl;
 
-const std::vector<const Property*> propTypeDefs = {
-    new PropertyT<std::optional<double>>{
+const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+    std::make_shared<PropertyT<std::optional<double>>>(
         "longitude", [](const JSONObject* props) { return dynamic_cast<const ViewState*>(props)->longitude; },
-        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->longitude = value; }, 0.0},
-    new PropertyT<std::optional<double>>{
+        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->longitude = value; }, 0.0),
+    std::make_shared<PropertyT<std::optional<double>>>(
         "latitude", [](const JSONObject* props) { return dynamic_cast<const ViewState*>(props)->latitude; },
-        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->latitude = value; }, 0.0},
-    new PropertyT<std::optional<double>>{
+        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->latitude = value; }, 0.0),
+    std::make_shared<PropertyT<std::optional<double>>>(
         "zoom", [](const JSONObject* props) { return dynamic_cast<const ViewState*>(props)->zoom; },
-        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->zoom = value; }, 10},
-    new PropertyT<std::optional<double>>{
+        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->zoom = value; }, 10),
+    std::make_shared<PropertyT<std::optional<double>>>(
         "bearing", [](const JSONObject* props) { return dynamic_cast<const ViewState*>(props)->bearing; },
-        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->bearing = value; }, 0.0},
-    new PropertyT<std::optional<double>>{
+        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->bearing = value; }, 0.0),
+    std::make_shared<PropertyT<std::optional<double>>>(
         "pitch", [](const JSONObject* props) { return dynamic_cast<const ViewState*>(props)->pitch; },
-        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->pitch = value; }, 0.0}};
+        [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->pitch = value; }, 0.0)};
 
-auto ViewState::getProperties() const -> const Properties* {
-  static Properties properties{Properties::from<ViewState>("ViewState", propTypeDefs)};
-  return &properties;
+auto ViewState::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<ViewState>("ViewState", propTypeDefs);
+  return properties;
 }

--- a/cpp/modules/deck.gl/core/src/views/view-state.cpp
+++ b/cpp/modules/deck.gl/core/src/views/view-state.cpp
@@ -40,6 +40,6 @@ const std::vector<std::shared_ptr<Property>> propTypeDefs = {
         [](JSONObject* props, const double& value) { return dynamic_cast<ViewState*>(props)->pitch = value; }, 0.0)};
 
 auto ViewState::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<ViewState>("ViewState", propTypeDefs);
+  static auto properties = Properties::from<ViewState>(propTypeDefs);
   return properties;
 }

--- a/cpp/modules/deck.gl/core/src/views/view-state.h
+++ b/cpp/modules/deck.gl/core/src/views/view-state.h
@@ -21,6 +21,7 @@
 #ifndef DECKGL_CORE_VIEWS_VIEW_STATE_H
 #define DECKGL_CORE_VIEWS_VIEW_STATE_H
 
+#include <memory>
 #include <optional>
 
 #include "deck.gl/json.h"
@@ -30,8 +31,7 @@ namespace deckgl {
 class ViewState : public JSONObject {
  public:
   using super = JSONObject;
-  static constexpr const char* getTypeName() { return "ViewState"; }
-  auto getProperties() const -> const Properties* override;
+
   virtual ~ViewState() {}
 
   // Map view states
@@ -40,6 +40,10 @@ class ViewState : public JSONObject {
   std::optional<double> zoom;
   std::optional<double> bearing;
   std::optional<double> pitch;
+
+  // Property Type Machinery
+  static constexpr const char* getTypeName() { return "ViewState"; }
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
 };
 
 }  // namespace deckgl

--- a/cpp/modules/deck.gl/core/src/views/view.cpp
+++ b/cpp/modules/deck.gl/core/src/views/view.cpp
@@ -26,7 +26,7 @@ using namespace std;
 using namespace deckgl;
 using namespace mathgl;
 
-const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+const std::vector<std::shared_ptr<Property>> propTypeDefs = {
     std::make_shared<PropertyT<string>>(
         "id", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->id; },
         [](JSONObject* props, string value) { return dynamic_cast<View*>(props)->id = value; }, ""),

--- a/cpp/modules/deck.gl/core/src/views/view.cpp
+++ b/cpp/modules/deck.gl/core/src/views/view.cpp
@@ -55,7 +55,7 @@ const std::vector<std::shared_ptr<Property>> propTypeDefs = {
         std::numeric_limits<double>::max())};
 
 auto View::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<View>("View", propTypeDefs);
+  static auto properties = Properties::from<View>(propTypeDefs);
   return properties;
 }
 

--- a/cpp/modules/deck.gl/core/src/views/view.cpp
+++ b/cpp/modules/deck.gl/core/src/views/view.cpp
@@ -26,31 +26,37 @@ using namespace std;
 using namespace deckgl;
 using namespace mathgl;
 
-const std::vector<const Property*> propTypeDefs = {
-    new PropertyT<string>{"id", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->id; },
-                          [](JSONObject* props, string value) { return dynamic_cast<View*>(props)->id = value; }, ""},
-    new PropertyT<int>{"x", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->x; },
-                       [](JSONObject* props, int value) { return dynamic_cast<View*>(props)->x = value; }, 0},
-    new PropertyT<int>{"y", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->y; },
-                       [](JSONObject* props, int value) { return dynamic_cast<View*>(props)->y = value; }, 0},
-    new PropertyT<int>{"width", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->width; },
-                       [](JSONObject* props, int value) { return dynamic_cast<View*>(props)->width = value; }, 100},
-    new PropertyT<int>{"height", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->height; },
-                       [](JSONObject* props, int value) { return dynamic_cast<View*>(props)->height = value; }, 100},
+const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+    std::make_shared<PropertyT<string>>(
+        "id", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->id; },
+        [](JSONObject* props, string value) { return dynamic_cast<View*>(props)->id = value; }, ""),
+    std::make_shared<PropertyT<int>>(
+        "x", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->x; },
+        [](JSONObject* props, int value) { return dynamic_cast<View*>(props)->x = value; }, 0),
+    std::make_shared<PropertyT<int>>(
+        "y", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->y; },
+        [](JSONObject* props, int value) { return dynamic_cast<View*>(props)->y = value; }, 0),
+    std::make_shared<PropertyT<int>>(
+        "width", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->width; },
+        [](JSONObject* props, int value) { return dynamic_cast<View*>(props)->width = value; }, 100),
+    std::make_shared<PropertyT<int>>(
+        "height", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->height; },
+        [](JSONObject* props, int value) { return dynamic_cast<View*>(props)->height = value; }, 100),
 
-    new PropertyT<double>{"fovy", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->fovy; },
-                          [](JSONObject* props, double value) { return dynamic_cast<View*>(props)->fovy = value; },
-                          1.0},
-    new PropertyT<double>{"near", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->near; },
-                          [](JSONObject* props, double value) { return dynamic_cast<View*>(props)->near = value; },
-                          0.0},
-    new PropertyT<double>{"far", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->far; },
-                          [](JSONObject* props, double value) { return dynamic_cast<View*>(props)->far = value; },
-                          std::numeric_limits<double>::max()}};
+    std::make_shared<PropertyT<double>>(
+        "fovy", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->fovy; },
+        [](JSONObject* props, double value) { return dynamic_cast<View*>(props)->fovy = value; }, 1.0),
+    std::make_shared<PropertyT<double>>(
+        "near", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->near; },
+        [](JSONObject* props, double value) { return dynamic_cast<View*>(props)->near = value; }, 0.0),
+    std::make_shared<PropertyT<double>>(
+        "far", [](const JSONObject* props) { return dynamic_cast<const View*>(props)->far; },
+        [](JSONObject* props, double value) { return dynamic_cast<View*>(props)->far = value; },
+        std::numeric_limits<double>::max())};
 
-auto View::getProperties() const -> const Properties* {
-  static Properties properties{Properties::from<View>("View", propTypeDefs)};
-  return &properties;
+auto View::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<View>("View", propTypeDefs);
+  return properties;
 }
 
 View::~View() {}

--- a/cpp/modules/deck.gl/core/src/views/view.h
+++ b/cpp/modules/deck.gl/core/src/views/view.h
@@ -34,13 +34,19 @@ namespace deckgl {
 
 class ViewManager;
 
-class View : public JSONObject {
+class View : public Component::Props {
   friend class ViewManager;
 
  public:
-  using super = JSONObject;
+  using super = Component::Props;
 
-  std::string id;
+  virtual ~View();
+
+  auto getViewStateId() const -> std::string;
+
+  // Build a `Viewport` from a view descriptor
+  auto makeViewport(const mathgl::Rectangle<int> &rect, std::shared_ptr<ViewState> viewState)
+      -> std::shared_ptr<Viewport>;
 
   // width/height of view
   int x{0};
@@ -59,15 +65,7 @@ class View : public JSONObject {
 
   // Property type machinery
   static constexpr const char *getTypeName() { return "View"; }
-  auto getProperties() const -> const Properties * override;
-
-  virtual ~View();
-
-  auto getViewStateId() const -> std::string;
-
-  // Build a `Viewport` from a view descriptor
-  auto makeViewport(const mathgl::Rectangle<int> &rect, std::shared_ptr<ViewState> viewState)
-      -> std::shared_ptr<Viewport>;
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
 
  protected:
   // Create actual viewport

--- a/cpp/modules/deck.gl/core/test/viewports/web-mercator-viewport-test.cpp
+++ b/cpp/modules/deck.gl/core/test/viewports/web-mercator-viewport-test.cpp
@@ -93,8 +93,6 @@ TEST_F(WebMercatorViewportTest, projectFlat) {
 //       auto xyz3 = viewport.project(lnglatIn3);
 //       auto lnglat3 = viewport.unproject(xyz3);
 
-//       std::cout << lnglatIn3 << xyz3 << lnglat3 << std::endl;
-
 //       EXPECT_NEAR(lnglatIn3.x, lnglat3.x, LNGLAT_TOLERANCE);
 //       EXPECT_NEAR(lnglatIn3.y, lnglat3.y, LNGLAT_TOLERANCE);
 //       EXPECT_NEAR(lnglatIn3.z, lnglat3.z, ALT_TOLERANCE);
@@ -110,8 +108,6 @@ TEST_F(WebMercatorViewportTest, projectFlat) {
 //       auto lnglatIn = Vector2<double>(viewport.longitude + offset, viewport.latitude + offset);
 //       auto xy = viewport.project(lnglatIn);
 //       auto lnglat = viewport.unproject(xy);
-
-//       std::cout << lnglatIn3 << xyz3 << lnglat3 << std::endl;
 
 //       EXPECT_NEAR(lnglatIn.x, lnglat.x, LNGLAT_TOLERANCE);
 //       EXPECT_NEAR(lnglatIn.y, lnglat.y, LNGLAT_TOLERANCE);

--- a/cpp/modules/deck.gl/json/src/json-object/json-object.cpp
+++ b/cpp/modules/deck.gl/json/src/json-object/json-object.cpp
@@ -53,7 +53,7 @@ auto Property::_getPropListFromJson(JSONObject* props, const Json::Value& jsonVa
 // Properties
 
 Properties::Properties(const std::string& className, const std::shared_ptr<Properties>& parentProps,
-                       const std::vector<const std::shared_ptr<Property>>& ownPropertyDefs)
+                       const std::vector<std::shared_ptr<Property>>& ownPropertyDefs)
     : className{className}, parent{parentProps} {
   // insert our prop types
   for (auto element : ownPropertyDefs) {

--- a/cpp/modules/deck.gl/json/src/json-object/json-object.cpp
+++ b/cpp/modules/deck.gl/json/src/json-object/json-object.cpp
@@ -22,7 +22,7 @@
 
 #include <iostream>
 
-#include "../converter/json-converter.h"  // {JSONConverter}
+#include "../converter/json-converter.h"
 
 using namespace deckgl;
 
@@ -52,17 +52,17 @@ auto Property::_getPropListFromJson(JSONObject* props, const Json::Value& jsonVa
 
 // Properties
 
-Properties::Properties(const std::string& className_, const Properties* parentProperties,
-                       const std::vector<const Property*>& ownPropertyDefs)
-    : className{className_}, parent{parentProperties} {
+Properties::Properties(const std::string& className, const std::shared_ptr<Properties>& parentProps,
+                       const std::vector<const std::shared_ptr<Property>>& ownPropertyDefs)
+    : className{className}, parent{parentProps} {
   // insert our prop types
   for (auto element : ownPropertyDefs) {
     this->_propTypeMap.insert({element->name, element});
   }
 
   // Insert parent's prop types
-  if (parentProperties) {
-    const auto& parentPropertyMap = parentProperties->_propTypeMap;
+  if (parentProps) {
+    const auto& parentPropertyMap = parentProps->_propTypeMap;
     this->_propTypeMap.insert(parentPropertyMap.begin(), parentPropertyMap.end());
   }
 }
@@ -73,9 +73,9 @@ JSONObject::JSONObject() {}
 
 JSONObject::~JSONObject() {}
 
-auto JSONObject::getProperties() const -> const Properties* {
-  static Properties properties{"Component", nullptr, std::vector<const Property*>{}};
-  return &properties;
+auto JSONObject::getProperties() const -> const std::shared_ptr<Properties> {
+  // Can't use make_shared here as constructor is private
+  return std::shared_ptr<deckgl::Properties>(new Properties{"Component", nullptr, {}});
 }
 
 void JSONObject::setPropertyFromJson(const std::string& key, const Json::Value& jsonValue,
@@ -84,14 +84,12 @@ void JSONObject::setPropertyFromJson(const std::string& key, const Json::Value& 
   propertyType->setPropertyFromJson(this, jsonValue, jsonConverter);
 }
 
-auto JSONObject::getProperty(const std::string& key) const -> const Property* {
-  // std::cout << "getProperties" << std::endl;
+auto JSONObject::getProperty(const std::string& key) const -> const std::shared_ptr<Property> {
   auto properties = this->getProperties();
   if (!properties) {
     throw std::logic_error("Component does not have property types");
   }
 
-  // std::cout << "getProperty" << std::endl;
   auto propertyType = this->getProperties()->getProperty(key);
   if (!propertyType) {
     throw std::runtime_error("Prop type not found for property " + key);
@@ -117,7 +115,7 @@ auto JSONObject::equals(const JSONObject* other) const -> bool {
     // Accessing KEY from element
     std::string name = element.first;
     // Accessing VALUE from element.
-    const Property* propType = element.second;
+    const auto propType = element.second;
     if (!propType->equals(this, other)) {
       return false;
     }
@@ -143,7 +141,7 @@ auto JSONObject::compare(const JSONObject* other) const -> std::optional<std::st
     // Accessing KEY from element
     std::string name = element.first;
     // Accessing VALUE from element.
-    const Property* propType = element.second;
+    const auto propType = element.second;
     if (!propType->equals(this, other)) {
       return properties->className + "." + propType->name + " changed";
     }

--- a/cpp/modules/deck.gl/json/src/json-object/json-object.h
+++ b/cpp/modules/deck.gl/json/src/json-object/json-object.h
@@ -277,20 +277,15 @@ class Properties {
   friend class JSONObject;
 
  public:
-  // static methods
   template <typename JSONObjectT>
-  static auto from(const std::string& className, const std::vector<std::shared_ptr<Property>>& properties = {})
+  static auto from(const std::vector<std::shared_ptr<Property>>& properties = {})
       -> std::shared_ptr<deckgl::Properties> {
+    auto className = JSONObjectT::getTypeName();
     typename JSONObjectT::super parentProps;
     // Can't use make_shared here as constructor is private
     return std::shared_ptr<deckgl::Properties>(new Properties{className, parentProps.getProperties(), properties});
   }
 
-  // public members
-  const std::string className;
-  const std::shared_ptr<Properties> parent;
-
-  // methods
   bool hasProp(const std::string& key) const { return this->_propTypeMap.count(key) == 1; }
   auto getProperty(const std::string& key) const -> const std::shared_ptr<Property> {
     auto searchIterator = this->_propTypeMap.find(key);
@@ -307,6 +302,9 @@ class Properties {
     }
     return properties;
   }
+
+  const std::string className;
+  const std::shared_ptr<Properties> parent;
 
  private:
   Properties(const std::string& className, const std::shared_ptr<Properties>& parentProps,

--- a/cpp/modules/deck.gl/json/src/json-object/json-object.h
+++ b/cpp/modules/deck.gl/json/src/json-object/json-object.h
@@ -21,6 +21,8 @@
 #ifndef DECKGL_JSON_JSON_OBJECT_H
 #define DECKGL_JSON_JSON_OBJECT_H
 
+#include <json/json.h>
+
 #include <functional>
 #include <iostream>
 #include <list>
@@ -29,9 +31,8 @@
 #include <string>
 #include <vector>
 
-#include "../converter/json-types-mathgl.h"  // {fromJson<T>(math.gl types)}
-#include "../converter/json-types.h"         // {fromJson<T>(std types)}
-#include "json/json.h"                       // {Json::Value}
+#include "../converter/json-types-mathgl.h"
+#include "../converter/json-types.h"
 
 namespace deckgl {
 // Forward declarations for operators
@@ -45,7 +46,7 @@ auto operator!=(const deckgl::JSONObject& lhs, const deckgl::JSONObject& rhs) ->
 namespace deckgl {
 
 // Forward declarations from other files
-class JSONConverter;  // #include "../converter/json-converter.h"
+class JSONConverter;
 
 class Properties;
 class Property;
@@ -60,7 +61,7 @@ class JSONObject {
   virtual ~JSONObject();
 
   // Returns the shared static Properties for this Prop object.
-  virtual auto getProperties() const -> const Properties*;
+  virtual auto getProperties() const -> const std::shared_ptr<Properties>;
 
   // Compares the contents of this prop object against another prop object
   auto equals(const JSONObject* other) const -> bool;
@@ -80,7 +81,7 @@ class JSONObject {
   void setPropertyFromJson(const std::string& key, const Json::Value& jsonValue, const JSONConverter*);
 
   // Gets the general property type object for a key
-  auto getProperty(const std::string& key) const -> const Property*;
+  auto getProperty(const std::string& key) const -> const std::shared_ptr<Property>;
 
   // Get the typed property type object for a key
   template <class T>
@@ -220,7 +221,7 @@ template <class T>
 struct PropertyT<std::list<std::shared_ptr<T>>> : public Property {
  public:
   // TODO(isaac@unfolded.ai): Possibly incorrect passing of references here
-  std::function<auto(JSONObject const*)->const std::list<std::shared_ptr<T>>&>
+  std::function<auto(const JSONObject*)->const std::list<std::shared_ptr<T>>&>
       get;  // TODO(ib@unfolded.ai): return const T& ?
   std::function<void(JSONObject*, const std::list<std::shared_ptr<T>>&)> set;
   std::list<std::shared_ptr<T>> defaultValue;
@@ -278,27 +279,28 @@ class Properties {
  public:
   // static methods
   template <typename JSONObjectT>
-  static auto from(const std::string& className, const std::vector<const Property*>& properties = {})
-      -> deckgl::Properties {
+  static auto from(const std::string& className, const std::vector<const std::shared_ptr<Property>>& properties = {})
+      -> std::shared_ptr<deckgl::Properties> {
     typename JSONObjectT::super parentProps;
-    return Properties{className, parentProps.getProperties(), properties};
+    // Can't use make_shared here as constructor is private
+    return std::shared_ptr<deckgl::Properties>(new Properties{className, parentProps.getProperties(), properties});
   }
 
   // public members
   const std::string className;
-  const Properties* parent;
+  const std::shared_ptr<Properties> parent;
 
   // methods
   bool hasProp(const std::string& key) const { return this->_propTypeMap.count(key) == 1; }
-  auto getProperty(const std::string& key) const -> const Property* {
+  auto getProperty(const std::string& key) const -> const std::shared_ptr<Property> {
     auto searchIterator = this->_propTypeMap.find(key);
     if (searchIterator == this->_propTypeMap.end()) {
       throw std::runtime_error("No such property: " + className + "." + key);
     }
     return searchIterator->second;
   }
-  auto allProperties() const -> std::vector<const Property*> {
-    std::vector<const Property*> properties;
+  auto allProperties() const -> std::vector<const std::shared_ptr<Property>> {
+    std::vector<const std::shared_ptr<Property>> properties;
     properties.reserve(this->_propTypeMap.size());
     for (auto prop : _propTypeMap) {
       properties.push_back(prop.second);
@@ -307,9 +309,10 @@ class Properties {
   }
 
  private:
-  Properties(const std::string& className, const Properties* parentProps, const std::vector<const Property*>&);
+  Properties(const std::string& className, const std::shared_ptr<Properties>& parentProps,
+             const std::vector<const std::shared_ptr<Property>>& ownPropertyDefs);
 
-  std::map<const std::string, const Property*> _propTypeMap;
+  std::map<const std::string, const std::shared_ptr<Property>> _propTypeMap;
 };
 
 // JSONObject inline members
@@ -323,7 +326,7 @@ void JSONObject::setProperty(const std::string& key, const T& value) {
     throw std::logic_error("Props: No prop types found");
   }
   if (auto propType = this->getProperties()->getProperty(key)) {
-    if (auto propTypeT = dynamic_cast<const PropertyT<T>*>(propType)) {
+    if (auto propTypeT = std::dynamic_pointer_cast<const PropertyT<T>>(propType)) {
       propTypeT->set(this, value);
     }
   }

--- a/cpp/modules/deck.gl/json/src/json-object/json-object.h
+++ b/cpp/modules/deck.gl/json/src/json-object/json-object.h
@@ -279,7 +279,7 @@ class Properties {
  public:
   // static methods
   template <typename JSONObjectT>
-  static auto from(const std::string& className, const std::vector<const std::shared_ptr<Property>>& properties = {})
+  static auto from(const std::string& className, const std::vector<std::shared_ptr<Property>>& properties = {})
       -> std::shared_ptr<deckgl::Properties> {
     typename JSONObjectT::super parentProps;
     // Can't use make_shared here as constructor is private
@@ -299,8 +299,8 @@ class Properties {
     }
     return searchIterator->second;
   }
-  auto allProperties() const -> std::vector<const std::shared_ptr<Property>> {
-    std::vector<const std::shared_ptr<Property>> properties;
+  auto allProperties() const -> std::vector<std::shared_ptr<Property>> {
+    std::vector<std::shared_ptr<Property>> properties;
     properties.reserve(this->_propTypeMap.size());
     for (auto prop : _propTypeMap) {
       properties.push_back(prop.second);
@@ -310,7 +310,7 @@ class Properties {
 
  private:
   Properties(const std::string& className, const std::shared_ptr<Properties>& parentProps,
-             const std::vector<const std::shared_ptr<Property>>& ownPropertyDefs);
+             const std::vector<std::shared_ptr<Property>>& ownPropertyDefs);
 
   std::map<const std::string, const std::shared_ptr<Property>> _propTypeMap;
 };

--- a/cpp/modules/deck.gl/json/src/json.h
+++ b/cpp/modules/deck.gl/json/src/json.h
@@ -23,6 +23,6 @@
 
 #include "./converter/json-converter.h"
 #include "./converter/json-types-mathgl.h"
-#include "./converter/json-types.h"  // {fromJson}
+#include "./converter/json-types.h"
 
 #endif  // DECKGL_JSON_JSON_H

--- a/cpp/modules/deck.gl/json/test/json-data.h
+++ b/cpp/modules/deck.gl/json/test/json-data.h
@@ -21,90 +21,65 @@
 static auto jsonDataFull = R"JSON(
 {
   "@@type": "Deck",
-  "description": "Test",
+  "id": "TestDeck",
+  "width": 640,
+  "height": 480,
   "initialViewState": {
     "longitude": -122.45,
     "latitude": 37.8,
-    "zoom": 12
+    "zoom": 12,
+    "bearing": 20,
+    "pitch": 30
   },
+  "views": [
+    {
+      "@@type": "MapView",
+      "id": "FirstView",
+      "x": 5,
+      "y": 10,
+      "width": 400,
+      "height": 300,
+      "fovy": 70.0,
+      "near": 1.0,
+      "far": 500.0
+    },
+    {
+      "@@type": "View"
+    }
+  ],
   "layers": [
     {
+      "@@type": "LineLayer",
+      "id": "LineLayer",
+      "data": [],
+      "visible": false,
+      "opacity": 0.5,
+      "coordinateOrigin": [5.0, 3.0, 2.0],
+      "coordinateSystem": 1,
+      "wrapLongitude": true,
+      "positionFormat": "YZX",
+      "colorFormat": "BGRA",
+      "widthUnits": "meters",
+      "widthScale": 2.0,
+      "widthMinPixels": 1.0,
+      "widthMaxPixels": 100.0
+    },
+    {
       "@@type": "ScatterplotLayer",
-      "data": [
-        {
-          "position": [
-            -122.45,
-            37.8
-          ]
-        }
-      ],
-      "getFillColor": [
-        255,
-        0,
-        0,
-        255
-      ],
-      "getRadius": 1000
-    },
-    {
-      "@@type": "TextLayer",
-      "data": [
-        {
-          "position": [
-            -122.45,
-            37.8
-          ],
-          "text": "Hello World"
-        }
-      ],
-      "getTextAnchor": "end"
-    },
-    {
-      "@@type": "GeoJsonLayer",
-      "data": {
-        "type": "FeatureCollection",
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {},
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -122.42923736572264,
-                37.80544394934271
-              ]
-            }
-          }
-        ]
-      },
+      "filled": false,
       "stroked": true,
-      "filled": true,
-      "lineWidthMinPixels": 2,
-      "opacity": 0.4,
-      "getLineColor": [
-        255,
-        100,
-        100
-      ],
-      "getFillColor": [
-        200,
-        160,
-        0,
-        180
-      ]
+      "lineWidthUnits": "pixels",
+      "lineWidthScale": 2,
+      "lineWidthMinPixels": 1,
+      "lineWidthMaxPixels": 5.2,
+      "radiusScale": 3,
+      "radiusMinPixels": 1,
+      "radiusMaxPixels": 10
     },
     {
-      "@@type": "PointCloudLayer",
-      "data": [
-        {
-	  "position": [-122.4, 37.7, 12],
-	  "normal": [-1, 0, 0],
-	  "color": [255, 255, 0]
-	}
-      ],
-      "pointSize": 10,
-      "coordinateSystem": "@@#COORDINATE_SYSTEM.METER_OFFSETS",
-      "coordinateOrigin": [-122.4, 37.74]
+      "@@type": "SolidPolygonLayer",
+      "filled": false,
+      "elevationScale": 2
     }
   ]
 }
@@ -113,7 +88,7 @@ static auto jsonDataFull = R"JSON(
 static auto jsonDataSimple = R"JSON(
 {
   "@@type": "Deck",
-  "description": "Test",
+  "id": "TestDeck",
   "initialViewState": {
     "longitude": -122.45,
     "latitude": 37.8,

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -29,28 +29,28 @@
 using namespace deckgl;
 using namespace lumagl;
 
-const std::vector<const Property*> propTypeDefs = {
-    new PropertyT<std::string>{
+const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+    std::make_shared<PropertyT<std::string>>(
         "widthUnits", [](const JSONObject* props) { return dynamic_cast<const LineLayer::Props*>(props)->widthUnits; },
         [](JSONObject* props, std::string value) { return dynamic_cast<LineLayer::Props*>(props)->widthUnits = value; },
-        "pixels"},
-    new PropertyT<float>{
+        "pixels"),
+    std::make_shared<PropertyT<float>>(
         "widthScale", [](const JSONObject* props) { return dynamic_cast<const LineLayer::Props*>(props)->widthScale; },
-        [](JSONObject* props, float value) { return dynamic_cast<LineLayer::Props*>(props)->widthScale = value; }, 1.0},
-    new PropertyT<float>{
+        [](JSONObject* props, float value) { return dynamic_cast<LineLayer::Props*>(props)->widthScale = value; }, 1.0),
+    std::make_shared<PropertyT<float>>(
         "widthMinPixels",
         [](const JSONObject* props) { return dynamic_cast<const LineLayer::Props*>(props)->widthMinPixels; },
         [](JSONObject* props, float value) { return dynamic_cast<LineLayer::Props*>(props)->widthMinPixels = value; },
-        0.0},
-    new PropertyT<float>{
+        0.0),
+    std::make_shared<PropertyT<float>>(
         "widthMaxPixels",
         [](const JSONObject* props) { return dynamic_cast<const LineLayer::Props*>(props)->widthMaxPixels; },
         [](JSONObject* props, float value) { return dynamic_cast<LineLayer::Props*>(props)->widthMaxPixels = value; },
-        std::numeric_limits<float>::max()}};
+        std::numeric_limits<float>::max())};
 
-auto LineLayer::Props::getProperties() const -> const Properties* {
-  static Properties properties{Properties::from<LineLayer::Props>("LineLayer", propTypeDefs)};
-  return &properties;
+auto LineLayer::Props::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<LineLayer::Props>("LineLayer", propTypeDefs);
+  return properties;
 }
 
 void LineLayer::initializeState() {

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -49,7 +49,7 @@ const std::vector<std::shared_ptr<Property>> propTypeDefs = {
         std::numeric_limits<float>::max())};
 
 auto LineLayer::Props::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<LineLayer::Props>("LineLayer", propTypeDefs);
+  static auto properties = Properties::from<LineLayer::Props>(propTypeDefs);
   return properties;
 }
 

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.cpp
@@ -29,7 +29,7 @@
 using namespace deckgl;
 using namespace lumagl;
 
-const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+const std::vector<std::shared_ptr<Property>> propTypeDefs = {
     std::make_shared<PropertyT<std::string>>(
         "widthUnits", [](const JSONObject* props) { return dynamic_cast<const LineLayer::Props*>(props)->widthUnits; },
         [](JSONObject* props, std::string value) { return dynamic_cast<LineLayer::Props*>(props)->widthUnits = value; },

--- a/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
+++ b/cpp/modules/deck.gl/layers/src/line-layer/line-layer.h
@@ -64,14 +64,8 @@ class LineLayer : public Layer {
 class LineLayer::Props : public Layer::Props {
  public:
   using super = Layer::Props;
-  static constexpr const char* getTypeName() { return "LineLayer"; }
 
-  // Property Type Machinery
-  auto getProperties() const -> const Properties* override;
-  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
-    return std::make_shared<LineLayer>(std::dynamic_pointer_cast<LineLayer::Props>(props));
-  }
-
+  // TODO(ilija@unfolded.ai): Should be an enum
   std::string widthUnits{"pixels"};
   float widthScale{1};
   float widthMinPixels{0};
@@ -85,6 +79,13 @@ class LineLayer::Props : public Layer::Props {
   std::function<ArrowMapper::Vector4FloatAccessor> getColor{
       [](const Row&) { return mathgl::Vector4<float>(0.0, 0.0, 0.0, 255.0); }};
   std::function<ArrowMapper::FloatAccessor> getWidth{[](const Row&) { return 1.0; }};
+
+  // Property Type Machinery
+  static constexpr const char* getTypeName() { return "LineLayer"; }
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
+  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
+    return std::make_shared<LineLayer>(std::dynamic_pointer_cast<LineLayer::Props>(props));
+  }
 };
 
 /// The order of fields in this structure is crucial for it to be mapped to its GLSL counterpart properly.

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
@@ -26,69 +26,69 @@
 using namespace deckgl;
 using namespace lumagl;
 
-const std::vector<const Property*> propTypeDefs = {
-    new PropertyT<bool>{
+const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+    std::make_shared<PropertyT<bool>>(
         "filled", [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->filled; },
         [](JSONObject* props, bool value) { return dynamic_cast<ScatterplotLayer::Props*>(props)->filled = value; },
-        true},
-    new PropertyT<bool>{
+        true),
+    std::make_shared<PropertyT<bool>>(
         "stroked", [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->stroked; },
         [](JSONObject* props, bool value) { return dynamic_cast<ScatterplotLayer::Props*>(props)->stroked = value; },
-        false},
-    new PropertyT<std::string>{
+        false),
+    std::make_shared<PropertyT<std::string>>(
         "lineWidthUnits",
         [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->lineWidthUnits; },
         [](JSONObject* props, std::string value) {
           return dynamic_cast<ScatterplotLayer::Props*>(props)->lineWidthUnits = value;
         },
-        "meters"},
-    new PropertyT<float>{
+        "meters"),
+    std::make_shared<PropertyT<float>>(
         "lineWidthScale",
         [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->lineWidthScale; },
         [](JSONObject* props, float value) {
           return dynamic_cast<ScatterplotLayer::Props*>(props)->lineWidthScale = value;
         },
-        1.0},
-    new PropertyT<float>{
+        1.0),
+    std::make_shared<PropertyT<float>>(
         "lineWidthMinPixels",
         [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->lineWidthMinPixels; },
         [](JSONObject* props, float value) {
           return dynamic_cast<ScatterplotLayer::Props*>(props)->lineWidthMinPixels = value;
         },
-        0.0},
-    new PropertyT<float>{
+        0.0),
+    std::make_shared<PropertyT<float>>(
         "lineWidthMaxPixels",
         [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->lineWidthMaxPixels; },
         [](JSONObject* props, float value) {
           return dynamic_cast<ScatterplotLayer::Props*>(props)->lineWidthMaxPixels = value;
         },
-        std::numeric_limits<float>::max()},
-    new PropertyT<float>{
+        std::numeric_limits<float>::max()),
+    std::make_shared<PropertyT<float>>(
         "radiusScale",
         [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->radiusScale; },
         [](JSONObject* props, float value) {
           return dynamic_cast<ScatterplotLayer::Props*>(props)->radiusScale = value;
         },
-        1.0},
-    new PropertyT<float>{
+        1.0),
+    std::make_shared<PropertyT<float>>(
         "radiusMinPixels",
         [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->radiusMinPixels; },
         [](JSONObject* props, float value) {
           return dynamic_cast<ScatterplotLayer::Props*>(props)->radiusMinPixels = value;
         },
-        0.0},
+        0.0),
 
-    new PropertyT<float>{
+    std::make_shared<PropertyT<float>>(
         "radiusMaxPixels",
         [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->radiusMaxPixels; },
         [](JSONObject* props, float value) {
           return dynamic_cast<ScatterplotLayer::Props*>(props)->radiusMaxPixels = value;
         },
-        std::numeric_limits<float>::max()}};
+        std::numeric_limits<float>::max())};
 
-auto ScatterplotLayer::Props::getProperties() const -> const Properties* {
-  static Properties properties{Properties::from<ScatterplotLayer::Props>("ScatterplotLayer", propTypeDefs)};
-  return &properties;
+auto ScatterplotLayer::Props::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<ScatterplotLayer::Props>("ScatterplotLayer", propTypeDefs);
+  return properties;
 }
 
 void ScatterplotLayer::initializeState() {

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
@@ -87,7 +87,7 @@ const std::vector<std::shared_ptr<Property>> propTypeDefs = {
         std::numeric_limits<float>::max())};
 
 auto ScatterplotLayer::Props::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<ScatterplotLayer::Props>("ScatterplotLayer", propTypeDefs);
+  static auto properties = Properties::from<ScatterplotLayer::Props>(propTypeDefs);
   return properties;
 }
 

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.cpp
@@ -26,7 +26,7 @@
 using namespace deckgl;
 using namespace lumagl;
 
-const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+const std::vector<std::shared_ptr<Property>> propTypeDefs = {
     std::make_shared<PropertyT<bool>>(
         "filled", [](const JSONObject* props) { return dynamic_cast<const ScatterplotLayer::Props*>(props)->filled; },
         [](JSONObject* props, bool value) { return dynamic_cast<ScatterplotLayer::Props*>(props)->filled = value; },

--- a/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
+++ b/cpp/modules/deck.gl/layers/src/scatterplot-layer/scatterplot-layer.h
@@ -63,13 +63,6 @@ class ScatterplotLayer : public Layer {
 class ScatterplotLayer::Props : public Layer::Props {
  public:
   using super = Layer::Props;
-  static constexpr const char* getTypeName() { return "ScatterplotLayer"; }
-
-  // Property Type Machinery
-  auto getProperties() const -> const Properties* override;
-  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
-    return std::make_shared<ScatterplotLayer>(std::dynamic_pointer_cast<ScatterplotLayer::Props>(props));
-  }
 
   bool filled{true};
   bool stroked{false};
@@ -92,6 +85,13 @@ class ScatterplotLayer::Props : public Layer::Props {
   std::function<ArrowMapper::Vector4FloatAccessor> getLineColor{
       [](const Row&) { return mathgl::Vector4<float>(0.0, 0.0, 0.0, 255.0); }};
   std::function<ArrowMapper::FloatAccessor> getLineWidth{[](auto row) { return 1.0; }};
+
+  // Property Type Machinery
+  static constexpr const char* getTypeName() { return "ScatterplotLayer"; }
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
+  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
+    return std::make_shared<ScatterplotLayer>(std::dynamic_pointer_cast<ScatterplotLayer::Props>(props));
+  }
 };
 
 /// The order of fields in this structure is crucial for it to be mapped to its GLSL counterpart properly.

--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cpp
@@ -30,7 +30,7 @@
 using namespace deckgl;
 using namespace lumagl;
 
-const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+const std::vector<std::shared_ptr<Property>> propTypeDefs = {
     std::make_shared<PropertyT<bool>>(
         "filled", [](const JSONObject* props) { return dynamic_cast<const SolidPolygonLayer::Props*>(props)->filled; },
         [](JSONObject* props, bool value) { return dynamic_cast<SolidPolygonLayer::Props*>(props)->filled = value; },

--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cpp
@@ -44,7 +44,7 @@ const std::vector<std::shared_ptr<Property>> propTypeDefs = {
         1.0)};
 
 auto SolidPolygonLayer::Props::getProperties() const -> const std::shared_ptr<Properties> {
-  static auto properties = Properties::from<SolidPolygonLayer::Props>("SolidPolygonLayer", propTypeDefs);
+  static auto properties = Properties::from<SolidPolygonLayer::Props>(propTypeDefs);
   return properties;
 }
 

--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cpp
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cpp
@@ -30,22 +30,22 @@
 using namespace deckgl;
 using namespace lumagl;
 
-const std::vector<const Property*> propTypeDefs = {
-    new PropertyT<bool>{
+const std::vector<const std::shared_ptr<Property>> propTypeDefs = {
+    std::make_shared<PropertyT<bool>>(
         "filled", [](const JSONObject* props) { return dynamic_cast<const SolidPolygonLayer::Props*>(props)->filled; },
         [](JSONObject* props, bool value) { return dynamic_cast<SolidPolygonLayer::Props*>(props)->filled = value; },
-        true},
-    new PropertyT<float>{
+        true),
+    std::make_shared<PropertyT<float>>(
         "elevationScale",
         [](const JSONObject* props) { return dynamic_cast<const SolidPolygonLayer::Props*>(props)->elevationScale; },
-        [](JSONObject* props, bool value) {
+        [](JSONObject* props, float value) {
           return dynamic_cast<SolidPolygonLayer::Props*>(props)->elevationScale = value;
         },
-        1.0}};
+        1.0)};
 
-auto SolidPolygonLayer::Props::getProperties() const -> const Properties* {
-  static Properties properties{Properties::from<SolidPolygonLayer::Props>("SolidPolygonLayer", propTypeDefs)};
-  return &properties;
+auto SolidPolygonLayer::Props::getProperties() const -> const std::shared_ptr<Properties> {
+  static auto properties = Properties::from<SolidPolygonLayer::Props>("SolidPolygonLayer", propTypeDefs);
+  return properties;
 }
 
 void SolidPolygonLayer::initializeState() {

--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.h
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.h
@@ -68,13 +68,6 @@ class SolidPolygonLayer : public Layer {
 class SolidPolygonLayer::Props : public Layer::Props {
  public:
   using super = Layer::Props;
-  static constexpr const char* getTypeName() { return "SolidPolygonLayer"; }
-
-  // Property Type Machinery
-  auto getProperties() const -> const Properties* override;
-  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
-    return std::make_shared<SolidPolygonLayer>(std::dynamic_pointer_cast<SolidPolygonLayer::Props>(props));
-  }
 
   bool filled{true};
   // TODO(ilija@unfolded.ai): Extrusion currently not supported
@@ -91,6 +84,13 @@ class SolidPolygonLayer::Props : public Layer::Props {
       [](const Row&) { return mathgl::Vector4<float>(0.0, 0.0, 0.0, 255.0); }};
   std::function<ArrowMapper::Vector4FloatAccessor> getLineColor{
       [](const Row&) { return mathgl::Vector4<float>(0.0, 0.0, 0.0, 255.0); }};
+
+  // Property Type Machinery
+  static constexpr const char* getTypeName() { return "SolidPolygonLayer"; }
+  auto getProperties() const -> const std::shared_ptr<Properties> override;
+  auto makeComponent(std::shared_ptr<Component::Props> props) const -> std::shared_ptr<Component> override {
+    return std::make_shared<SolidPolygonLayer>(std::dynamic_pointer_cast<SolidPolygonLayer::Props>(props));
+  }
 };
 
 /// The order of fields in this structure is crucial for it to be mapped to its GLSL counterpart properly.

--- a/cpp/modules/deck.gl/layers/test/line-layer-test.cpp
+++ b/cpp/modules/deck.gl/layers/test/line-layer-test.cpp
@@ -108,7 +108,6 @@ TEST_F(LineLayerTest, Create) {
 }
 
 TEST_F(LineLayerTest, GetSourcePositionData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<LineLayer::Props>();
   layerProps->data = propData;
 
@@ -131,7 +130,6 @@ TEST_F(LineLayerTest, GetSourcePositionData) {
 }
 
 TEST_F(LineLayerTest, GetTargetPositionData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<LineLayer::Props>();
   layerProps->data = propData;
 
@@ -154,7 +152,6 @@ TEST_F(LineLayerTest, GetTargetPositionData) {
 }
 
 TEST_F(LineLayerTest, GetColorData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<LineLayer::Props>();
   layerProps->data = propData;
 
@@ -178,7 +175,6 @@ TEST_F(LineLayerTest, GetColorData) {
 }
 
 TEST_F(LineLayerTest, GetWidthData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<LineLayer::Props>();
   layerProps->data = propData;
 

--- a/cpp/modules/deck.gl/layers/test/scatterplot-layer-test.cpp
+++ b/cpp/modules/deck.gl/layers/test/scatterplot-layer-test.cpp
@@ -70,7 +70,6 @@ TEST_F(ScatterplotLayerTest, Props) {
 }
 
 TEST_F(ScatterplotLayerTest, GetPositionData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<ScatterplotLayer::Props>();
   layerProps->data = propData;
 
@@ -93,7 +92,6 @@ TEST_F(ScatterplotLayerTest, GetPositionData) {
 }
 
 TEST_F(ScatterplotLayerTest, GetRadiusData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<ScatterplotLayer::Props>();
   layerProps->data = propData;
 
@@ -108,7 +106,6 @@ TEST_F(ScatterplotLayerTest, GetRadiusData) {
 }
 
 TEST_F(ScatterplotLayerTest, GetFillColorData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<ScatterplotLayer::Props>();
   layerProps->data = propData;
 
@@ -132,7 +129,6 @@ TEST_F(ScatterplotLayerTest, GetFillColorData) {
 }
 
 TEST_F(ScatterplotLayerTest, GetLineColorData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<ScatterplotLayer::Props>();
   layerProps->data = propData;
 
@@ -156,7 +152,6 @@ TEST_F(ScatterplotLayerTest, GetLineColorData) {
 }
 
 TEST_F(ScatterplotLayerTest, GetLineWidthData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<ScatterplotLayer::Props>();
   layerProps->data = propData;
 

--- a/cpp/modules/deck.gl/layers/test/solid-polygon-layer-test.cpp
+++ b/cpp/modules/deck.gl/layers/test/solid-polygon-layer-test.cpp
@@ -130,7 +130,6 @@ TEST_F(SolidPolygonLayerTest, Create) {
 }
 
 TEST_F(SolidPolygonLayerTest, GetPolygonData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<SolidPolygonLayer::Props>();
   layerProps->data = propData;
 
@@ -155,7 +154,6 @@ TEST_F(SolidPolygonLayerTest, GetPolygonData) {
 }
 
 TEST_F(SolidPolygonLayerTest, GetElevationData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<SolidPolygonLayer::Props>();
   layerProps->data = propData;
 
@@ -171,7 +169,6 @@ TEST_F(SolidPolygonLayerTest, GetElevationData) {
 }
 
 TEST_F(SolidPolygonLayerTest, GetFillColorData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<SolidPolygonLayer::Props>();
   layerProps->data = propData;
 
@@ -196,7 +193,6 @@ TEST_F(SolidPolygonLayerTest, GetFillColorData) {
 }
 
 TEST_F(SolidPolygonLayerTest, GetLineColorData) {
-  // TODO(ilija@unfolded.ai): Props should be mocked in order to completely decouple this test from props implementation
   auto layerProps = std::make_shared<SolidPolygonLayer::Props>();
   layerProps->data = propData;
 

--- a/cpp/modules/math.gl/core/test/core-test.cpp
+++ b/cpp/modules/math.gl/core/test/core-test.cpp
@@ -24,40 +24,12 @@
 
 namespace {
 
-/**
- * The fixture for testing class Foo.
- */
+/// \brief The fixture for testing core math classes.
 class MathTest : public ::testing::Test {
  protected:
-  // You can remove any or all of the following functions if their bodies would
-  // be empty.
-
-  MathTest() {
-    // You can do set-up work for each test here.
-  }
-
-  ~MathTest() override {
-    // You can do clean-up work that doesn't throw exceptions here.
-  }
-
-  // If the constructor and destructor are not enough for setting up
-  // and cleaning up each test, you can define the following methods:
-
-  void SetUp() override {
-    // Code here will be called immediately after the constructor (right
-    // before each test).
-  }
-
-  void TearDown() override {
-    // Code here will be called immediately after each test (right
-    // before the destructor).
-  }
-
-  // Class members declared here can be used by all tests in the test suite
-  // for Foo.
+  MathTest() {}
 };
 
-// Tests Vector3 + operand
 TEST_F(MathTest, Vector3Sum) {
   mathgl::Vector3 vector1{0.1, 0.3, 0.5};
   mathgl::Vector3 vector2{0.6, 0.2, 0.1};

--- a/deck.gl-native.xcodeproj/project.pbxproj
+++ b/deck.gl-native.xcodeproj/project.pbxproj
@@ -2189,8 +2189,8 @@
 			buildPhases = (
 				CD227D572477DAE200B6083B /* Sources */,
 				CD227D582477DAE200B6083B /* Frameworks */,
-				CD227D592477DAE200B6083B /* CopyFiles */,
 				CD227D6C2477DB1E00B6083B /* Embed Libraries */,
+				CD227D592477DAE200B6083B /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -2208,8 +2208,8 @@
 			buildPhases = (
 				CD48E80C24178A1E00D3C13C /* Sources */,
 				CD48E80D24178A1E00D3C13C /* Frameworks */,
-				CD48E80E24178A1E00D3C13C /* CopyFiles */,
 				CD98D2DD2449AEB100E42B4F /* Embed Libraries */,
+				CD48E80E24178A1E00D3C13C /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -2225,10 +2225,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CD5856DD246135540076227F /* Build configuration list for PBXNativeTarget "flight-paths" */;
 			buildPhases = (
-				CD5856D7246135540076227F /* CopyFiles */,
 				CD5856D5246135540076227F /* Sources */,
 				CD5856D6246135540076227F /* Frameworks */,
 				CDCD8F2D24614F73009604C5 /* Embed Libraries */,
+				CD5856D7246135540076227F /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -2244,10 +2244,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CD5856F92461364B0076227F /* Build configuration list for PBXNativeTarget "manhattan-population" */;
 			buildPhases = (
-				CD5856F32461364B0076227F /* CopyFiles */,
 				CD5856F12461364B0076227F /* Sources */,
 				CD5856F22461364B0076227F /* Frameworks */,
 				CD58570A2461367E0076227F /* Embed Libraries */,
+				CD5856F32461364B0076227F /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -2283,8 +2283,8 @@
 			buildPhases = (
 				CDCD8F3224618413009604C5 /* Sources */,
 				CDCD8F3324618413009604C5 /* Frameworks */,
-				CDCD8F3424618413009604C5 /* CopyFiles */,
 				CD23526C24627CD500E3F139 /* Embed Libraries */,
+				CDCD8F3424618413009604C5 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -2300,10 +2300,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CDE53E9F243C69A4000D8EC6 /* Build configuration list for PBXNativeTarget "animometer" */;
 			buildPhases = (
-				CDE53E99243C69A4000D8EC6 /* CopyFiles */,
 				CDE53E97243C69A4000D8EC6 /* Sources */,
 				CDE53E98243C69A4000D8EC6 /* Frameworks */,
 				CD5856CD2461326C0076227F /* Embed Libraries */,
+				CDE53E99243C69A4000D8EC6 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/deck.gl-native.xcodeproj/project.pbxproj
+++ b/deck.gl-native.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		CD33DF3E242E220D003F3B96 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF3C242E2207003F3B96 /* QuartzCore.framework */; };
 		CD35949C2472C55900DC8289 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD33DF24242E1F65003F3B96 /* CoreFoundation.framework */; };
 		CD378923248634EC00418C4B /* solid-polygon-layer-test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD378922248634EC00418C4B /* solid-polygon-layer-test.cpp */; };
+		CD378925248689DE00418C4B /* component.cc in Sources */ = {isa = PBXBuildFile; fileRef = CD378924248689DE00418C4B /* component.cc */; };
 		CD452A462448421B00DD44A5 /* arrow-utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = CD452A432448421B00DD44A5 /* arrow-utils.cc */; };
 		CD452A472448421B00DD44A5 /* arrow-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = CD452A442448421B00DD44A5 /* arrow-utils.h */; };
 		CD452A51244852DE00DD44A5 /* field.h in Headers */ = {isa = PBXBuildFile; fileRef = CD452A4E244852DE00DD44A5 /* field.h */; };
@@ -473,6 +474,7 @@
 		CD33DF41242E2285003F3B96 /* libdawn_utils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdawn_utils.a; path = ../dawn/out/Debug/obj/libdawn_utils.a; sourceTree = "<group>"; };
 		CD33DF42242E2285003F3B96 /* libdawn_sample_utils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdawn_sample_utils.a; path = ../dawn/out/Debug/obj/libdawn_sample_utils.a; sourceTree = "<group>"; };
 		CD378922248634EC00418C4B /* solid-polygon-layer-test.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "solid-polygon-layer-test.cpp"; sourceTree = "<group>"; };
+		CD378924248689DE00418C4B /* component.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = component.cc; sourceTree = "<group>"; };
 		CD452A432448421B00DD44A5 /* arrow-utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "arrow-utils.cc"; sourceTree = "<group>"; };
 		CD452A442448421B00DD44A5 /* arrow-utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "arrow-utils.h"; sourceTree = "<group>"; };
 		CD452A4E244852DE00DD44A5 /* field.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = field.h; sourceTree = "<group>"; };
@@ -1839,6 +1841,7 @@
 				CDE55C25243C6A10000D8EC6 /* layer-manager.h */,
 				CDE55C26243C6A10000D8EC6 /* view-manager.cpp */,
 				CD6EC074247CFB2B009D6C00 /* earcut.hpp */,
+				CD378924248689DE00418C4B /* component.cc */,
 			);
 			path = lib;
 			sourceTree = "<group>";
@@ -2483,6 +2486,7 @@
 				CDE577EE243C6A1F000D8EC6 /* viewport.cpp in Sources */,
 				CDE5785C243C6A1F000D8EC6 /* csv-loader.cpp in Sources */,
 				CDE5774C243C6A1F000D8EC6 /* log.cpp in Sources */,
+				CD378925248689DE00418C4B /* component.cc in Sources */,
 				CDAD573B247242CC002736A3 /* metal-animation-loop.mm in Sources */,
 				CDE57819243C6A1F000D8EC6 /* viewport-uniforms.cpp in Sources */,
 				CD452A462448421B00DD44A5 /* arrow-utils.cc in Sources */,


### PR DESCRIPTION
- Added additional tests that cover parsing the entire `Deck` structure, with all the objects/properties we currently support
- Made `id` part of `Component::Props`
- Updated raw pointers being used by properties to `std::shared_ptr`. `Valgrind` now reports no memory leakage
- Minor fixups that made the tests fail