### PR TITLE
Fixed the polygon layer uniform alignment

### DIFF
--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cc
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.cc
@@ -100,9 +100,9 @@ void SolidPolygonLayer::updateState(const Layer::ChangeFlags& changeFlags,
 
   if (changeFlags.propsChanged) {
     SolidPolygonLayerUniforms uniforms;
+    uniforms.extruded = props->extruded ? 1 : 0;
+    uniforms.wireframe = props->wireframe ? 1 : 0;
     uniforms.elevationScale = props->elevationScale;
-    uniforms.extruded = props->extruded;
-    uniforms.wireframe = props->wireframe;
     uniforms.opacity = props->opacity;
     this->_layerUniforms.SetSubData(0, sizeof(SolidPolygonLayerUniforms), &uniforms);
   }

--- a/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.h
+++ b/cpp/modules/deck.gl/layers/src/solid-polygon-layer/solid-polygon-layer.h
@@ -94,11 +94,11 @@ class SolidPolygonLayer::Props : public Layer::Props {
 };
 
 /// The order of fields in this structure is crucial for it to be mapped to its GLSL counterpart properly.
-/// bool has a 4-byte alignment in GLSL.
+/// Using uint32_t in place of bool in order to avoid packing issues, even when specifying 4-byte alignment.
 /// https://learnopengl.com/Advanced-OpenGL/Advanced-GLSL
 struct SolidPolygonLayerUniforms {
-  alignas(4) bool extruded;
-  alignas(4) bool wireframe;
+  uint32_t extruded;
+  uint32_t wireframe;
   float elevationScale;
   float opacity;
 };


### PR DESCRIPTION
While updating our iOS examples, I figured that the issue wasn't only with runs from terminal, as I wasn't getting anything drawn in the sample iOS app. This was much easier to debug there as I could inspect the actual data.

I tried a few things in order to fix the alignment and keep the `bool` members, but I was not able to get it working consistently, even with use of `#pragma pack`. I switched these over to `uint32_t` as that's guaranteed not to fail regardless of the compiler