### PR TITLE
Deck size propagation tuneups

### DIFF
--- a/cpp/modules/deck.gl/core/src/lib/deck.h
+++ b/cpp/modules/deck.gl/core/src/lib/deck.h
@@ -59,9 +59,6 @@ class Deck : public Component {
   auto props() { return std::dynamic_pointer_cast<Props>(this->_props); }
   void setProps(std::shared_ptr<Deck::Props> props);
 
-  int width{100};   // Dummy value, ensure something is visible if user forgets to set window size
-  int height{100};  // Dummy value, ensure something is visible if user forgets to set window size
-
   void run(std::function<void(Deck*)> onAfterRender = [](Deck*) {});
   void draw(
       wgpu::TextureView textureView, std::function<void(Deck*)> onAfterRender = [](Deck*) {});
@@ -74,6 +71,8 @@ class Deck : public Component {
 
   auto getViews() -> std::list<std::shared_ptr<View>> { return this->viewManager->getViews(); }
 
+  auto size() -> lumagl::Size { return this->_size; };
+
   std::shared_ptr<lumagl::AnimationLoop> animationLoop;
   std::shared_ptr<ViewManager> viewManager{new ViewManager()};
   std::shared_ptr<LayerContext> context;
@@ -85,13 +84,15 @@ class Deck : public Component {
   /// \brief Get the most relevant view state: props.viewState, if supplied, shadows internal viewState.
   auto _getViewState() -> std::shared_ptr<ViewState>;
 
-  auto _createAnimationLoop(const std::shared_ptr<Deck::Props>& props) -> std::shared_ptr<lumagl::AnimationLoop>;
+  void _setSize(const lumagl::Size& size);
+
   void _redraw(wgpu::RenderPassEncoder pass, std::function<void(Deck*)> onAfterRender, bool force = false);
   void _drawLayers(wgpu::RenderPassEncoder pass, std::function<void(Deck*)> onAfterRender,
                    const std::string& redrawReason);
 
   std::optional<std::string> _needsRedraw;
   wgpu::Buffer _viewportUniformsBuffer;
+  lumagl::Size _size;
 };
 
 class Deck::Props : public Component::Props {

--- a/cpp/modules/luma.gl/CMakeLists.txt
+++ b/cpp/modules/luma.gl/CMakeLists.txt
@@ -77,6 +77,7 @@ set(CORE_SOURCE_FILE_LIST
     core/src/animation-loop.cc
     core/src/model.cc
     core/src/blit-model.cc
+    core/src/size.cc
     )
 set(CORE_TESTS_SOURCE_FILE_LIST
     )

--- a/cpp/modules/luma.gl/core/src/animation-loop.cc
+++ b/cpp/modules/luma.gl/core/src/animation-loop.cc
@@ -85,7 +85,7 @@ void AnimationLoop::run(std::function<void(wgpu::RenderPassEncoder)> onRender) {
 void AnimationLoop::stop() { this->running = false; }
 
 void AnimationLoop::setSize(const Size& size) {
-  bool sizeChanged = size.width != this->_size.width || size.height != this->_size.height;
+  bool sizeChanged = size != this->_size;
   if (sizeChanged) {
     this->_size = size;
     // TODO(ilija@unfolded.ai): Trigger redraw

--- a/cpp/modules/luma.gl/core/src/glfw-animation-loop.cc
+++ b/cpp/modules/luma.gl/core/src/glfw-animation-loop.cc
@@ -93,9 +93,11 @@ auto GLFWAnimationLoop::devicePixelRatio() -> float {
 }
 
 void GLFWAnimationLoop::setSize(const Size& size) {
-  bool sizeChanged = size.width != this->_size.width || size.height != this->_size.height;
+  bool sizeChanged = size != this->_size;
   if (sizeChanged) {
-    this->_swapchain = this->_createSwapchain(this->_device);
+    glfwSetWindowSize(this->_window, size.width, size.height);
+    this->_swapchain.Configure(this->getPreferredSwapChainTextureFormat(), wgpu::TextureUsage::OutputAttachment,
+                               size.width, size.height);
   }
 
   super::setSize(size);
@@ -160,10 +162,6 @@ auto GLFWAnimationLoop::_initializeGLFW(const wgpu::BackendType backendType, con
   if (!window) {
     throw std::runtime_error("Failed to create GLFW window");
   }
-  // TODO(ilija@unfolded.ai): Handle window resizing
-  //  glfwSetFramebufferSizeCallback(window, [this](GLFWwindow* window, int width, int height) {
-  //    this->setSize(width, height);
-  //  });
 
   return window;
 }

--- a/cpp/modules/luma.gl/core/src/metal-animation-loop.mm
+++ b/cpp/modules/luma.gl/core/src/metal-animation-loop.mm
@@ -67,10 +67,10 @@ auto MetalAnimationLoop::devicePixelRatio() -> float {
 }
 
 void MetalAnimationLoop::setSize(const Size& size) {
-  bool sizeChanged = size.width != this->_size.width || size.height != this->_size.height;
+  bool sizeChanged = size != this->_size;
   if (sizeChanged) {
-    // TODO(ilija@unfolded.ai): Should we be trying to resize users views/layers?
-    //    this->_swapchain = this->_createSwapchain(this->_device);
+    this->_swapchain.Configure(this->getPreferredSwapChainTextureFormat(), wgpu::TextureUsage::OutputAttachment,
+                               size.width, size.height);
   }
 
   super::setSize(size);

--- a/cpp/modules/luma.gl/core/src/size.cc
+++ b/cpp/modules/luma.gl/core/src/size.cc
@@ -18,28 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef LUMAGL_CORE_SIZE_H
-#define LUMAGL_CORE_SIZE_H
+#include "./size.h"  // NOLINT(build/include)
 
-namespace lumagl {
+using namespace lumagl;
 
-struct Size {
- public:
-  Size() : width{0}, height{0} {}
-  Size(int width, int height) : width{width}, height{height} {}
+auto operator==(const Size& s1, const Size& s2) -> bool { return s1.width == s2.width && s1.height == s2.height; }
 
-  template <typename T>
-  auto operator*(const T& value) -> Size {
-    return Size{static_cast<int>(this->width * value), static_cast<int>(this->height * value)};
-  }
-
-  int width;
-  int height;
-};
-
-}  // namespace lumagl
-
-auto operator==(const lumagl::Size& s1, const lumagl::Size& s2) -> bool;
-auto operator!=(const lumagl::Size& s1, const lumagl::Size& s2) -> bool;
-
-#endif  // LUMAGL_CORE_SIZE_H
+auto operator!=(const Size& s1, const Size& s2) -> bool { return !(s1 == s2); }

--- a/cpp/modules/luma.gl/webgpu/src/backends/glfw/metal-binding.mm
+++ b/cpp/modules/luma.gl/webgpu/src/backends/glfw/metal-binding.mm
@@ -66,14 +66,18 @@ class SwapChainImplMTL {
     ASSERT(height > 0);
 
     NSView* contentView = [mNsWindow contentView];
-    [contentView setWantsLayer:YES];
-
     // Make sure display scale factor is taken into account
     CGSize drawableSize = CGSizeMake(width * mNsWindow.backingScaleFactor, height * mNsWindow.backingScaleFactor);
 
-    mLayer = [CAMetalLayer layer];
-    [mLayer setDevice:mMtlDevice];
-    [mLayer setPixelFormat:MTLPixelFormatBGRA8Unorm];
+    // If swapchain was not configured previously, create a new layer and set it up
+    if (!mLayer) {
+      [contentView setWantsLayer:YES];
+
+      mLayer = [CAMetalLayer layer];
+      [mLayer setDevice:mMtlDevice];
+      [mLayer setPixelFormat:MTLPixelFormatBGRA8Unorm];
+    }
+
     [mLayer setDrawableSize:drawableSize];
 
     constexpr uint32_t kFramebufferOnlyTextureUsages = WGPUTextureUsage_OutputAttachment | WGPUTextureUsage_Present;

--- a/cpp/modules/luma.gl/webgpu/src/backends/metal-binding.mm
+++ b/cpp/modules/luma.gl/webgpu/src/backends/metal-binding.mm
@@ -60,8 +60,11 @@ class SwapChainImplMTL {
     // Make sure UI methods are called on the main thread
     // No retain cycle here as there is no reference counting in C++
     executeOnMainThread(^{
-      this->_view.device = mMtlDevice;
-      this->mLayer = (CAMetalLayer*)this->_view.layer;
+      // If swapchain was not configured previously, create a new layer and set it up
+      if (!this->mLayer) {
+        this->_view.device = mMtlDevice;
+        this->mLayer = (CAMetalLayer*)this->_view.layer;
+      }
 
       constexpr uint32_t kFramebufferOnlyTextureUsages = WGPUTextureUsage_OutputAttachment | WGPUTextureUsage_Present;
       bool hasOnlyFramebufferUsages = !(usage & (~kFramebufferOnlyTextureUsages));

--- a/deck.gl-native.xcodeproj/project.pbxproj
+++ b/deck.gl-native.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		CDAD574224724CD7002736A3 /* metal-binding.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDAD574024724CD7002736A3 /* metal-binding.mm */; };
 		CDAD574324724CD7002736A3 /* metal-binding.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAD574124724CD7002736A3 /* metal-binding.h */; };
 		CDAD5745247258BA002736A3 /* animation-loop-factory.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAD5744247258BA002736A3 /* animation-loop-factory.h */; };
+		CDAE9BE0248E00E6002B6253 /* size.cc in Sources */ = {isa = PBXBuildFile; fileRef = CDAE9BDF248E00E6002B6253 /* size.cc */; };
 		CDC5AB592487A06F008D76B9 /* libarrow.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC5AB5724879D2E008D76B9 /* libarrow.a */; };
 		CDC5AB5B2487AD8E008D76B9 /* libdawn_native.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = CDE57860243C70F5000D8EC6 /* libdawn_native.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		CDC5AB5C2487AD8E008D76B9 /* libdawn_proc.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = CDE5786A243C70F6000D8EC6 /* libdawn_proc.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -403,6 +404,7 @@
 		CDAD574124724CD7002736A3 /* metal-binding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "metal-binding.h"; sourceTree = "<group>"; };
 		CDAD5744247258BA002736A3 /* animation-loop-factory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "animation-loop-factory.h"; sourceTree = "<group>"; };
 		CDAD574924726745002736A3 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		CDAE9BDF248E00E6002B6253 /* size.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = size.cc; sourceTree = "<group>"; };
 		CDC5AB5724879D2E008D76B9 /* libarrow.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libarrow.a; path = "cpp/deps/x64-osx/lib/libarrow.a"; sourceTree = "<group>"; };
 		CDC5AB5824879FE5008D76B9 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		CDC5AB5F2487B403008D76B9 /* error.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = error.h; sourceTree = "<group>"; };
@@ -1021,6 +1023,7 @@
 			isa = PBXGroup;
 			children = (
 				CD57341124640E6200D22A70 /* size.h */,
+				CDAE9BDF248E00E6002B6253 /* size.cc */,
 				CDE55B4A243C6A10000D8EC6 /* model.h */,
 				CDE55B4B243C6A10000D8EC6 /* model.cc */,
 				CD57340E24640A3300D22A70 /* blit-model.h */,
@@ -1941,6 +1944,7 @@
 				CDE577A7243C6A1F000D8EC6 /* web-mercator-utils-test.cc in Sources */,
 				CD57340F24640A3300D22A70 /* blit-model.cc in Sources */,
 				CDE577FC243C6A1F000D8EC6 /* deck.cc in Sources */,
+				CDAE9BE0248E00E6002B6253 /* size.cc in Sources */,
 				CDE57781243C6A1F000D8EC6 /* webgpu-helpers.cc in Sources */,
 				CD227D5324779BE500B6083B /* solid-polygon-layer.cc in Sources */,
 				CD452A552448565000DD44A5 /* schema.cc in Sources */,


### PR DESCRIPTION
Updating the size through Deck props should work across the board, [iOS examples](https://github.com/UnfoldedInc/ios-showcase) updated with these changes, and the orientation is no longer locked to landscape