### PR TITLE
Exception-free API consolidated

### DIFF
--- a/cpp/examples/deck.gl/texture-render.cc
+++ b/cpp/examples/deck.gl/texture-render.cc
@@ -88,7 +88,7 @@ auto createDeck(const char* argv[], const wgpu::Device& device, const lumagl::Si
   deckProps->drawingOptions = std::make_shared<DrawingOptions>(device, device.CreateQueue());
 
   probegl::Error error;
-  auto deck = Deck::make(error, deckProps);
+  auto deck = Deck::make(deckProps, error);
   noErrorOrTerminate(error);
 
   return deck;
@@ -111,7 +111,7 @@ int main(int argc, const char* argv[]) {
   lumagl::Size windowSize{640, 480};
   auto options = std::make_shared<GLFWAnimationLoop::Options>(windowSize, "Texture Render");
   probegl::Error error;
-  auto animationLoop = AnimationLoopFactory::createAnimationLoop(error, options);
+  auto animationLoop = AnimationLoopFactory::createAnimationLoop(options, error);
   auto device = animationLoop->device();
 
   auto framebufferSize = windowSize * animationLoop->devicePixelRatio();

--- a/cpp/modules/deck.gl/core/src/lib/deck.cc
+++ b/cpp/modules/deck.gl/core/src/lib/deck.cc
@@ -57,21 +57,33 @@ auto Deck::Props::getProperties() const -> const std::shared_ptr<Properties> {
   return properties;
 }
 
-auto Deck::make(probegl::Error& error, std::shared_ptr<Deck::Props> props) noexcept -> std::shared_ptr<Deck> {
+auto Deck::make(std::shared_ptr<Deck::Props> props, probegl::Error& error) noexcept -> std::shared_ptr<Deck> {
   return probegl::catchError<Deck>([&]() { return Deck{props}; }, error);
+}
+
+auto Deck::make(probegl::Error& error) noexcept -> std::shared_ptr<Deck> {
+  return probegl::catchError<Deck>([&]() { return Deck{}; }, error);
 }
 
 void Deck::setProps(std::shared_ptr<Deck::Props> props, probegl::Error& error) noexcept {
   probegl::catchError([&]() { this->setProps(props); }, error);
 }
 
-void Deck::run(probegl::Error& error, std::function<void(Deck*)> onAfterRender) noexcept {
+void Deck::run(std::function<void(Deck*)> onAfterRender, probegl::Error& error) noexcept {
   probegl::catchError([&]() { this->run(onAfterRender); }, error);
 }
 
-void Deck::draw(wgpu::TextureView textureView, probegl::Error& error,
-                std::function<void(Deck*)> onAfterRender) noexcept {
+void Deck::run(probegl::Error& error) noexcept {
+  probegl::catchError([&]() { this->run(); }, error);
+}
+
+void Deck::draw(wgpu::TextureView textureView, std::function<void(Deck*)> onAfterRender,
+                probegl::Error& error) noexcept {
   probegl::catchError([&]() { this->draw(textureView, onAfterRender); }, error);
+}
+
+void Deck::draw(wgpu::TextureView textureView, probegl::Error& error) noexcept {
+  probegl::catchError([&]() { this->draw(textureView); }, error);
 }
 
 Deck::Deck(std::shared_ptr<Deck::Props> props) : Component(props), _needsRedraw{"Initial render"} {

--- a/cpp/modules/deck.gl/core/src/lib/deck.h
+++ b/cpp/modules/deck.gl/core/src/lib/deck.h
@@ -41,15 +41,14 @@ class Deck : public Component {
 
 #pragma mark - Exception-free API
 
-  static auto make(probegl::Error& error, std::shared_ptr<Deck::Props> props = std::make_shared<Deck::Props>()) noexcept
-      -> std::shared_ptr<Deck>;
+  static auto make(std::shared_ptr<Deck::Props> props, probegl::Error& error) noexcept -> std::shared_ptr<Deck>;
+  static auto make(probegl::Error& error) noexcept -> std::shared_ptr<Deck>;
   void setProps(std::shared_ptr<Deck::Props> props, probegl::Error& error) noexcept;
 
-  void run(
-      probegl::Error& error, std::function<void(Deck*)> onAfterRender = [](Deck*) {}) noexcept;
-  void draw(
-      wgpu::TextureView textureView, probegl::Error& error,
-      std::function<void(Deck*)> onAfterRender = [](Deck*) {}) noexcept;
+  void run(std::function<void(Deck*)> onAfterRender, probegl::Error& error) noexcept;
+  void run(probegl::Error& error) noexcept;
+  void draw(wgpu::TextureView textureView, std::function<void(Deck*)> onAfterRender, probegl::Error& error) noexcept;
+  void draw(wgpu::TextureView textureView, probegl::Error& error) noexcept;
 
 #pragma mark -
 

--- a/cpp/modules/luma.gl/CMakeLists.txt
+++ b/cpp/modules/luma.gl/CMakeLists.txt
@@ -78,6 +78,7 @@ set(CORE_SOURCE_FILE_LIST
     core/src/model.cc
     core/src/blit-model.cc
     core/src/size.cc
+    core/src/animation-loop-factory.cc
     )
 set(CORE_TESTS_SOURCE_FILE_LIST
     )

--- a/cpp/modules/luma.gl/core/src/animation-loop-factory.cc
+++ b/cpp/modules/luma.gl/core/src/animation-loop-factory.cc
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 Unfolded Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "./animation-loop-factory.h"  // NOLINT(build/include)
+
+using namespace lumagl;
+
+auto AnimationLoopFactory::createAnimationLoop(const std::shared_ptr<AnimationLoop::Options>& options,
+                                               probegl::Error& error) noexcept -> std::shared_ptr<AnimationLoop> {
+  return probegl::catchError<AnimationLoop>([options]() { return createAnimationLoop(options); }, error);
+}
+
+auto AnimationLoopFactory::createAnimationLoop(probegl::Error& error) noexcept -> std::shared_ptr<AnimationLoop> {
+  return probegl::catchError<AnimationLoop>([]() { return createAnimationLoop(); }, error);
+}
+
+auto AnimationLoopFactory::createAnimationLoop(const std::shared_ptr<AnimationLoop::Options>& options)
+    -> std::shared_ptr<AnimationLoop> {
+  // If no options are passed, try and initialize the only setup which requires no arguments, which is GLFW
+  if (!options) {
+#if defined(LUMAGL_USES_GLFW)
+    GLFWAnimationLoop::Options opts;
+    return std::make_shared<GLFWAnimationLoop>(opts);
+#else
+    return nullptr;
+#endif
+  }
+
+#if defined(LUMAGL_USES_GLFW)
+  if (auto glfwOptions = std::dynamic_pointer_cast<GLFWAnimationLoop::Options>(options)) {
+    return std::make_shared<GLFWAnimationLoop>(*glfwOptions.get());
+  }
+#endif
+
+#if defined(LUMAGL_ENABLE_BACKEND_METAL)
+  if (auto metalOptions = std::dynamic_pointer_cast<MetalAnimationLoop::Options>(options)) {
+    return std::make_shared<MetalAnimationLoop>(*metalOptions.get());
+  }
+#endif
+
+  return std::make_shared<AnimationLoop>(*options.get());
+}

--- a/cpp/modules/luma.gl/core/src/animation-loop-factory.h
+++ b/cpp/modules/luma.gl/core/src/animation-loop-factory.h
@@ -29,45 +29,19 @@
 
 namespace lumagl {
 
+// TODO(ilija@unfolded.ai): Revisit this API
 struct AnimationLoopFactory {
  public:
 #pragma mark - Exception-free API
 
-  static auto createAnimationLoop(probegl::Error& error,
-                                  const std::shared_ptr<AnimationLoop::Options>& options = nullptr) noexcept
-      -> std::shared_ptr<AnimationLoop> {
-    return probegl::catchError<AnimationLoop>([options]() { return createAnimationLoop(options); }, error);
-  }
+  static auto createAnimationLoop(const std::shared_ptr<AnimationLoop::Options>& options,
+                                  probegl::Error& error) noexcept -> std::shared_ptr<AnimationLoop>;
+  static auto createAnimationLoop(probegl::Error& error) noexcept -> std::shared_ptr<AnimationLoop>;
 
 #pragma mark -
 
-  // TODO(ilija@unfolded.ai): Revisit
   static auto createAnimationLoop(const std::shared_ptr<AnimationLoop::Options>& options = nullptr)
-      -> std::shared_ptr<AnimationLoop> {
-    // If no options are passed, try and initialize the only setup which requires no arguments, which is GLFW
-    if (!options) {
-#if defined(LUMAGL_USES_GLFW)
-      GLFWAnimationLoop::Options opts;
-      return std::make_shared<GLFWAnimationLoop>(opts);
-#else
-      return nullptr;
-#endif
-    }
-
-#if defined(LUMAGL_USES_GLFW)
-    if (auto glfwOptions = std::dynamic_pointer_cast<GLFWAnimationLoop::Options>(options)) {
-      return std::make_shared<GLFWAnimationLoop>(*glfwOptions.get());
-    }
-#endif
-
-#if defined(LUMAGL_ENABLE_BACKEND_METAL)
-    if (auto metalOptions = std::dynamic_pointer_cast<MetalAnimationLoop::Options>(options)) {
-      return std::make_shared<MetalAnimationLoop>(*metalOptions.get());
-    }
-#endif
-
-    return std::make_shared<AnimationLoop>(*options.get());
-  }
+      -> std::shared_ptr<AnimationLoop>;
 };
 
 }  // namespace lumagl

--- a/cpp/modules/luma.gl/garrow/src/field.cc
+++ b/cpp/modules/luma.gl/garrow/src/field.cc
@@ -22,6 +22,14 @@
 
 using namespace lumagl::garrow;
 
+Field::Field(const std::string& name, wgpu::VertexFormat type, bool nullable,
+             const std::shared_ptr<const KeyValueMetadata>& metadata)
+    : _name{name}, _type{type}, _nullable{nullable}, _metadata{metadata} {
+  if (nullable) {
+    throw std::runtime_error("Nullable fields currently not supported");
+  }
+}
+
 auto Field::Equals(const Field& other, bool check_metadata) const -> bool {
   if (this == &other) {
     return true;

--- a/cpp/modules/luma.gl/garrow/src/field.h
+++ b/cpp/modules/luma.gl/garrow/src/field.h
@@ -38,12 +38,7 @@ class Field {
   // NOTE: type is currently a simple wgpu::VertexFormat value. Arrow has a complex DataType implementation that
   // deals with buffer type complexity, which is something that should be put in place once we implement reading
   Field(const std::string& name, wgpu::VertexFormat type, bool nullable = false,
-        const std::shared_ptr<const KeyValueMetadata>& metadata = nullptr)
-      : _name{name}, _type{type}, _nullable{nullable}, _metadata{metadata} {
-    if (nullable) {
-      throw std::runtime_error("Nullable fields currently not supported");
-    }
-  }
+        const std::shared_ptr<const KeyValueMetadata>& metadata = nullptr);
 
   /// \brief Returns the field name.
   auto name() const -> const std::string& { return _name; }

--- a/deck.gl-native.xcodeproj/project.pbxproj
+++ b/deck.gl-native.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		CDAD574324724CD7002736A3 /* metal-binding.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAD574124724CD7002736A3 /* metal-binding.h */; };
 		CDAD5745247258BA002736A3 /* animation-loop-factory.h in Headers */ = {isa = PBXBuildFile; fileRef = CDAD5744247258BA002736A3 /* animation-loop-factory.h */; };
 		CDAE9BE0248E00E6002B6253 /* size.cc in Sources */ = {isa = PBXBuildFile; fileRef = CDAE9BDF248E00E6002B6253 /* size.cc */; };
+		CDAE9BEC248E2FAC002B6253 /* animation-loop-factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = CDAE9BEB248E2FAC002B6253 /* animation-loop-factory.cc */; };
 		CDC5AB592487A06F008D76B9 /* libarrow.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC5AB5724879D2E008D76B9 /* libarrow.a */; };
 		CDC5AB5B2487AD8E008D76B9 /* libdawn_native.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = CDE57860243C70F5000D8EC6 /* libdawn_native.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		CDC5AB5C2487AD8E008D76B9 /* libdawn_proc.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = CDE5786A243C70F6000D8EC6 /* libdawn_proc.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -405,6 +406,7 @@
 		CDAD5744247258BA002736A3 /* animation-loop-factory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "animation-loop-factory.h"; sourceTree = "<group>"; };
 		CDAD574924726745002736A3 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		CDAE9BDF248E00E6002B6253 /* size.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = size.cc; sourceTree = "<group>"; };
+		CDAE9BEB248E2FAC002B6253 /* animation-loop-factory.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "animation-loop-factory.cc"; sourceTree = "<group>"; };
 		CDC5AB5724879D2E008D76B9 /* libarrow.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libarrow.a; path = "cpp/deps/x64-osx/lib/libarrow.a"; sourceTree = "<group>"; };
 		CDC5AB5824879FE5008D76B9 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		CDC5AB5F2487B403008D76B9 /* error.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = error.h; sourceTree = "<group>"; };
@@ -1035,6 +1037,7 @@
 				CD64D44F24718F8C009A2A9C /* metal-animation-loop.h */,
 				CD64D44E24718F8C009A2A9C /* metal-animation-loop.mm */,
 				CDAD5744247258BA002736A3 /* animation-loop-factory.h */,
+				CDAE9BEB248E2FAC002B6253 /* animation-loop-factory.cc */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -1960,6 +1963,7 @@
 				CDE57852243C6A1F000D8EC6 /* json-loader.cc in Sources */,
 				CDE57810243C6A1F000D8EC6 /* view.cc in Sources */,
 				CDE577E5243C6A1F000D8EC6 /* arrow-mapper.cc in Sources */,
+				CDAE9BEC248E2FAC002B6253 /* animation-loop-factory.cc in Sources */,
 				CDE577F5243C6A1F000D8EC6 /* attribute-manager.cc in Sources */,
 				CDE5782F243C6A1F000D8EC6 /* layers.cc in Sources */,
 				CDE577AC243C6A1F000D8EC6 /* web-mercator-utils.cc in Sources */,


### PR DESCRIPTION
Moved `Error&` to last argument spot across the board. Revisited some of the APIs that throw and moved them out of headers.

There are 2 headers remaining that explicitly throw in our codebase - `json-object.h` and `core.h` from math.gl. Both of these have a pretty good reason to do so, and they do it in methods that are templated. I did not go too much in depth trying to analyze how many functions that we call out to from our headers could possibly throw, as I'm not sure whether we can/should get of throw API from the 2 header files I mentioned. Let's sync over this today and I can make any updates that might make sense